### PR TITLE
Fix safebrowsing patch

### DIFF
--- a/build.py
+++ b/build.py
@@ -70,19 +70,19 @@ def _test_python(error_exit):
     """
     Tests if Python 3 is setup with the proper requirements
     """
-    python3_exe = shutil.which('python')
+    python3_exe = shutil.which('py')
     if not python3_exe:
-        error_exit('Could not find "python" in PATH')
+        error_exit('Could not find "py" in PATH')
 
     # Check Python version is at least 3.6
     result = subprocess.run((python3_exe, '--version'),
-                            stderr=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
                             check=True,
                             universal_newlines=True)
-    match = re.fullmatch(r'Python 3\.([0-9])\.([0-9]+)', result.stderr.strip())
+    match = re.fullmatch(r'Python 3\.([0-9])\.([0-9]+)', result.stdout.strip())
     if not match:
         error_exit('Could not detect Python 3 version from output: {}'.format(
-            result.stderr.strip()))
+            result.stdout.strip()))
     if int(match.group(1)) < 6:
         error_exit('At least Python 3.6 is required; found 3.{}.{}'.format(
             match.group(1),

--- a/build.py
+++ b/build.py
@@ -70,19 +70,19 @@ def _test_python(error_exit):
     """
     Tests if Python 3 is setup with the proper requirements
     """
-    python3_exe = shutil.which('py')
+    python3_exe = shutil.which('python')
     if not python3_exe:
-        error_exit('Could not find "py" in PATH')
+        error_exit('Could not find "python" in PATH')
 
     # Check Python version is at least 3.6
     result = subprocess.run((python3_exe, '--version'),
-                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
                             check=True,
                             universal_newlines=True)
-    match = re.fullmatch(r'Python 3\.([0-9])\.([0-9]+)', result.stdout.strip())
+    match = re.fullmatch(r'Python 3\.([0-9])\.([0-9]+)', result.stderr.strip())
     if not match:
         error_exit('Could not detect Python 3 version from output: {}'.format(
-            result.stdout.strip()))
+            result.stderr.strip()))
     if int(match.group(1)) < 6:
         error_exit('At least Python 3.6 is required; found 3.{}.{}'.format(
             match.group(1),

--- a/flags.windows.gn
+++ b/flags.windows.gn
@@ -9,3 +9,4 @@ target_cpu="x64"
 use_gnome_keyring=false
 use_jumbo_build=true
 use_sysroot=false
+is_debug=false

--- a/patches/series
+++ b/patches/series
@@ -11,3 +11,4 @@ ungoogled-chromium/windows/windows-fix-enum-conflict.patch
 ungoogled-chromium/windows/windows-fix-building-gn.patch
 ungoogled-chromium/windows/windows-disable-encryption.patch
 ungoogled-chromium/windows/windows-disable-machine-id.patch
+ungoogled-chromium/windows/windows-fix-fingerprinting.patch

--- a/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
@@ -1182,7 +1182,22 @@
  #include "chrome/services/file_util/public/mojom/constants.mojom.h"
  #endif
  
-@@ -2419,10 +2402,6 @@ bool ChromeContentBrowserClient::AllowSi
+@@ -2127,14 +2110,6 @@ void ChromeContentBrowserClient::AppendE
+         }
+       }
+ 
+-      // Disable client-side phishing detection in the renderer if it is
+-      // disabled in the Profile preferences or the browser process.
+-      if (!prefs->GetBoolean(prefs::kSafeBrowsingEnabled) ||
+-          true) {
+-        command_line->AppendSwitch(
+-            switches::kDisableClientSidePhishingDetection);
+-      }
+-
+       if (prefs->GetBoolean(prefs::kPrintPreviewDisabled))
+         command_line->AppendSwitch(switches::kDisablePrintPreview);
+ 
+@@ -2419,10 +2394,6 @@ bool ChromeContentBrowserClient::AllowSi
      content::ResourceContext* resource_context) {
    DCHECK_CURRENTLY_ON(BrowserThread::IO);
    DCHECK(!base::FeatureList::IsEnabled(features::kNavigationLoaderOnUI));
@@ -1193,7 +1208,7 @@
    ProfileIOData* io_data = ProfileIOData::FromResourceContext(resource_context);
    return io_data->signed_exchange_enabled()->GetValue();
  }
-@@ -3722,21 +3701,6 @@ void ChromeContentBrowserClient::ExposeI
+@@ -3722,21 +3693,6 @@ void ChromeContentBrowserClient::ExposeI
          ui_task_runner);
    }
  
@@ -1215,7 +1230,7 @@
    if (data_reduction_proxy::params::IsEnabledWithNetworkService()) {
      registry->AddInterface(base::BindRepeating(
          &AddDataReductionProxyBinding,
-@@ -4196,15 +4160,6 @@ ChromeContentBrowserClient::CreateThrott
+@@ -4196,15 +4152,6 @@ ChromeContentBrowserClient::CreateThrott
      throttles.push_back(std::move(background_tab_navigation_throttle));
  #endif
  
@@ -1231,7 +1246,7 @@
    std::unique_ptr<content::NavigationThrottle>
        lookalike_url_navigation_throttle = lookalikes::
            LookalikeUrlNavigationThrottle::MaybeCreateNavigationThrottle(handle);
-@@ -4552,8 +4507,7 @@ ChromeContentBrowserClient::CreateURLLoa
+@@ -4552,8 +4499,7 @@ ChromeContentBrowserClient::CreateURLLoa
    ProfileIOData* io_data = nullptr;
    // Only set |io_data| if needed, as in unit tests |resource_context| is a
    // MockResourceContext and the cast doesn't work.
@@ -1241,7 +1256,7 @@
      io_data = ProfileIOData::FromResourceContext(resource_context);
    }
  
-@@ -4586,20 +4540,6 @@ ChromeContentBrowserClient::CreateURLLoa
+@@ -4586,20 +4532,6 @@ ChromeContentBrowserClient::CreateURLLoa
          headers, data_reduction_proxy_throttle_manager_.get()));
    }
  
@@ -1262,7 +1277,7 @@
    if (chrome_navigation_ui_data &&
        chrome_navigation_ui_data->prerender_mode() != prerender::NO_PRERENDER) {
      result.push_back(std::make_unique<prerender::PrerenderURLLoaderThrottle>(
-@@ -4688,18 +4628,6 @@ ChromeContentBrowserClient::CreateURLLoa
+@@ -4688,18 +4620,6 @@ ChromeContentBrowserClient::CreateURLLoa
          headers, data_reduction_proxy_throttle_manager_.get()));
    }
  
@@ -1281,7 +1296,7 @@
    if (chrome_navigation_ui_data &&
        chrome_navigation_ui_data->prerender_mode() != prerender::NO_PRERENDER) {
      result.push_back(std::make_unique<prerender::PrerenderURLLoaderThrottle>(
-@@ -5389,14 +5317,6 @@ void ChromeContentBrowserClient::SetDefa
+@@ -5389,14 +5309,6 @@ void ChromeContentBrowserClient::SetDefa
    g_default_quota_settings = settings;
  }
  
@@ -2603,7 +2618,7 @@
      }
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_FILE: {
        if (IsExtensionDownload()) {
-@@ -270,19 +268,11 @@ base::string16 DownloadUIModel::GetWarni
+@@ -270,20 +268,10 @@ base::string16 DownloadUIModel::GetWarni
      }
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_CONTENT:
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST: {
@@ -2617,15 +2632,16 @@
 -      request_ap_verdicts = safe_browsing::AdvancedProtectionStatusManager::
 -          RequestsAdvancedProtectionVerdicts(profile());
 -#endif
-       return l10n_util::GetStringFUTF16(
+-      return l10n_util::GetStringFUTF16(
 -          request_ap_verdicts
 -              ? IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT_IN_ADVANCED_PROTECTION
 -              : IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT,
-+          IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT,
-           elided_filename);
+-          elided_filename);
++      break;
      }
      case download::DOWNLOAD_DANGER_TYPE_POTENTIALLY_UNWANTED: {
-@@ -386,13 +376,6 @@ bool DownloadUIModel::ShouldPreferOpenin
+       return l10n_util::GetStringFUTF16(IDS_PROMPT_DOWNLOAD_CHANGES_SETTINGS,
+@@ -386,13 +374,6 @@ bool DownloadUIModel::ShouldPreferOpenin
  
  void DownloadUIModel::SetShouldPreferOpeningInBrowser(bool preference) {}
  
@@ -5873,3 +5889,14 @@
  
    ScheduleTask(base::BindRepeating(&PasswordStore::SaveEnterprisePasswordURLs,
                                     this, base::Passed(&enterprise_login_urls),
+--- a/components/search_engines/search_terms_data.cc
++++ b/components/search_engines/search_terms_data.cc
+@@ -21,7 +21,7 @@ std::string SearchTermsData::GoogleBaseU
+ std::string SearchTermsData::GoogleBaseSuggestURLValue() const {
+   // Start with the Google base URL.
+   const GURL base_url(GoogleBaseURLValue());
+-  DCHECK(base_url.is_valid());
++  //DCHECK(base_url.is_valid());
+ 
+   GURL::Replacements repl;
+ 

--- a/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
@@ -129,7 +129,15 @@
  #if defined(GOOGLE_CHROME_BUILD)
  #include "chrome/browser/component_updater/third_party_module_list_component_installer_win.h"
  #endif  // defined(GOOGLE_CHROME_BUILD)
-@@ -537,7 +536,6 @@ void RegisterComponentsForUpdate(PrefSer
+@@ -495,7 +494,6 @@ void RegisterComponentsForUpdate(PrefSer
+   whitelist_installer->RegisterComponents();
+ #endif
+ 
+-  RegisterSubresourceFilterComponent(cus);
+   RegisterOnDeviceHeadSuggestComponent(cus);
+   RegisterOptimizationHintsComponent(cus, profile_prefs);
+ 
+@@ -537,7 +535,6 @@ void RegisterComponentsForUpdate(PrefSer
    // on chromium build bots, it is always registered here and
    // RegisterSwReporterComponent() has support for running only in official
    // builds or tests.
@@ -137,6 +145,19 @@
  #if defined(GOOGLE_CHROME_BUILD)
    RegisterThirdPartyModuleListComponent(cus);
  #endif  // defined(GOOGLE_CHROME_BUILD)
+@@ -1256,12 +1253,6 @@ void ChromeBrowserMainParts::PreBrowserS
+   // other services to start up before we start adjusting the oom priority.
+   g_browser_process->GetTabManager()->Start();
+ #endif
+-
+-  // The RulesetService will make the filtering rules available to renderers
+-  // immediately after its construction, provided that the rules are already
+-  // available at no cost in an indexed format. This enables activating
+-  // subresource filtering, if needed, also for page loads on start-up.
+-  g_browser_process->subresource_filter_ruleset_service();
+ }
+ 
+ void ChromeBrowserMainParts::PostBrowserStart() {
 --- a/chrome/browser/chrome_browser_main_win.cc
 +++ b/chrome/browser/chrome_browser_main_win.cc
 @@ -44,9 +44,6 @@
@@ -420,7 +441,16 @@
      "//components/search",
      "//components/search_engines",
      "//components/security_interstitials/content:security_interstitial_page",
-@@ -1339,7 +1320,6 @@ jumbo_split_static_library("ui") {
+@@ -1251,8 +1232,6 @@ jumbo_split_static_library("ui") {
+       "webui/settings/appearance_handler.h",
+       "webui/settings/browser_lifetime_handler.cc",
+       "webui/settings/browser_lifetime_handler.h",
+-      "webui/settings/change_password_handler.cc",
+-      "webui/settings/change_password_handler.h",
+       "webui/settings/custom_home_pages_table_model.cc",
+       "webui/settings/custom_home_pages_table_model.h",
+       "webui/settings/downloads_handler.cc",
+@@ -1339,7 +1318,6 @@ jumbo_split_static_library("ui") {
        "//chrome/browser/profile_resetter:profile_reset_report_proto",
        "//chrome/browser/resource_coordinator:tab_metrics_event_proto",
        "//chrome/browser/resource_coordinator/tab_ranker",
@@ -428,7 +458,7 @@
        "//chrome/browser/ui/webui/app_management:mojo_bindings",
        "//chrome/common:buildflags",
        "//chrome/common:search_mojom",
-@@ -2296,10 +2276,6 @@ jumbo_split_static_library("ui") {
+@@ -2296,10 +2274,6 @@ jumbo_split_static_library("ui") {
        "startup/credential_provider_signin_info_fetcher_win.h",
        "startup/default_browser_prompt_win.cc",
        "views/certificate_viewer_win.cc",
@@ -439,7 +469,16 @@
        "views/color_chooser_dialog.cc",
        "views/color_chooser_dialog.h",
        "views/color_chooser_win.cc",
-@@ -2343,8 +2319,6 @@ jumbo_split_static_library("ui") {
+@@ -2320,8 +2294,6 @@ jumbo_split_static_library("ui") {
+       "views/frame/windows_10_caption_button.cc",
+       "views/frame/windows_10_caption_button.h",
+       "views/network_profile_bubble_view.cc",
+-      "views/settings_reset_prompt_dialog.cc",
+-      "views/settings_reset_prompt_dialog.h",
+       "views/status_icons/status_icon_win.cc",
+       "views/status_icons/status_icon_win.h",
+       "views/status_icons/status_tray_state_changer_win.cc",
+@@ -2343,8 +2315,6 @@ jumbo_split_static_library("ui") {
        "webui/conflicts/conflicts_handler.h",
        "webui/conflicts/conflicts_ui.cc",
        "webui/conflicts/conflicts_ui.h",
@@ -448,7 +487,7 @@
        "webui/settings_utils_win.cc",
        "webui/version_handler_win.cc",
        "webui/version_handler_win.h",
-@@ -2356,7 +2330,6 @@ jumbo_split_static_library("ui") {
+@@ -2356,7 +2326,6 @@ jumbo_split_static_library("ui") {
        "//ui/views/controls/webview",
      ]
      deps += [
@@ -456,7 +495,7 @@
        "//chrome/browser/ui/startup:buildflags",
        "//chrome/browser/win/conflicts:module_info",
        "//chrome/credential_provider/common:common_constants",
-@@ -2976,8 +2949,6 @@ jumbo_split_static_library("ui") {
+@@ -2976,8 +2945,6 @@ jumbo_split_static_library("ui") {
        "views/relaunch_notification/wall_clock_timer.h",
        "views/sad_tab_view.cc",
        "views/sad_tab_view.h",
@@ -465,7 +504,7 @@
        "views/send_tab_to_self/send_tab_to_self_bubble_device_button.cc",
        "views/send_tab_to_self/send_tab_to_self_bubble_device_button.h",
        "views/send_tab_to_self/send_tab_to_self_bubble_view_impl.cc",
-@@ -3823,15 +3794,6 @@ jumbo_split_static_library("ui") {
+@@ -3823,15 +3790,6 @@ jumbo_split_static_library("ui") {
      }
    }
  
@@ -719,7 +758,7 @@
  #endif
 -                              rappor::mojom::RapporRecorder,
 -                              safe_browsing::mojom::SafeBrowsing>())
-+                              rappor::mojom::RapporRecorder)
++                              rappor::mojom::RapporRecorder>())
          .RequireCapability("apps", "app_service")
          .RequireCapability("ash", "system_ui")
          .RequireCapability("ash", "test")
@@ -928,7 +967,22 @@
  #include "components/sessions/core/session_id_generator.h"
  #include "components/subresource_filter/content/browser/ruleset_service.h"
  #include "components/subresource_filter/core/browser/subresource_filter_constants.h"
-@@ -1232,38 +1231,6 @@ void BrowserProcessImpl::CreateBackgroun
+@@ -975,14 +974,6 @@ StatusTray* BrowserProcessImpl::status_t
+   return status_tray_.get();
+ }
+ 
+-subresource_filter::RulesetService*
+-BrowserProcessImpl::subresource_filter_ruleset_service() {
+-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  if (!created_subresource_filter_ruleset_service_)
+-    CreateSubresourceFilterRulesetService();
+-  return subresource_filter_ruleset_service_.get();
+-}
+-
+ optimization_guide::OptimizationGuideService*
+ BrowserProcessImpl::optimization_guide_service() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+@@ -1232,38 +1223,6 @@ void BrowserProcessImpl::CreateBackgroun
  #endif
  }
  
@@ -969,14 +1023,24 @@
    DCHECK(!optimization_guide_service_);
 --- a/chrome/browser/browser_process_impl.h
 +++ b/chrome/browser/browser_process_impl.h
-@@ -214,7 +214,6 @@ class BrowserProcessImpl : public Browse
+@@ -165,8 +165,6 @@ class BrowserProcessImpl : public Browse
+   void set_background_mode_manager_for_test(
+       std::unique_ptr<BackgroundModeManager> manager) override;
+   StatusTray* status_tray() override;
+-  subresource_filter::RulesetService* subresource_filter_ruleset_service()
+-      override;
+   optimization_guide::OptimizationGuideService* optimization_guide_service()
+       override;
+ 
+@@ -214,8 +212,6 @@ class BrowserProcessImpl : public Browse
    void CreateNotificationUIManager();
    void CreatePrintPreviewDialogController();
    void CreateBackgroundPrintingManager();
 -  void CreateSafeBrowsingService();
-   void CreateSubresourceFilterRulesetService();
+-  void CreateSubresourceFilterRulesetService();
    void CreateOptimizationGuideService();
    void CreateStatusTray();
+   void CreateBackgroundModeManager();
 --- a/chrome/browser/browser_resources.grd
 +++ b/chrome/browser/browser_resources.grd
 @@ -174,9 +174,6 @@
@@ -1587,7 +1651,16 @@
  // content::NotificationObserver implementation.
  void ChromeDownloadManagerDelegate::Observe(
      int type,
-@@ -1376,14 +1125,6 @@ bool ChromeDownloadManagerDelegate::Shou
+@@ -1236,8 +985,6 @@ void ChromeDownloadManagerDelegate::OnDo
+     if (item->GetOriginalMimeType() == "application/x-x509-user-cert")
+       DownloadItemModel(item).SetShouldPreferOpeningInBrowser(true);
+ #endif
+-
+-    DownloadItemModel(item).SetDangerLevel(target_info->danger_level);
+   }
+   if (ShouldBlockFile(target_info->danger_type, item)) {
+     target_info->result = download::DOWNLOAD_INTERRUPT_REASON_FILE_BLOCKED;
+@@ -1376,14 +1123,6 @@ bool ChromeDownloadManagerDelegate::Shou
  void ChromeDownloadManagerDelegate::MaybeSendDangerousDownloadOpenedReport(
      DownloadItem* download,
      bool show_download_in_folder) {
@@ -2413,7 +2486,23 @@
    DoLoop();
  }
  
-@@ -1027,38 +985,6 @@ bool DownloadTargetDeterminer::HasPrompt
+@@ -927,7 +885,6 @@ void DownloadTargetDeterminer::ScheduleC
+             << " Intermediate:" << intermediate_path_.AsUTF8Unsafe()
+             << " Confirmation reason:" << static_cast<int>(confirmation_reason_)
+             << " Danger type:" << danger_type_
+-            << " Danger level:" << danger_level_
+             << " Result:" << static_cast<int>(result);
+   std::unique_ptr<DownloadTargetInfo> target_info(new DownloadTargetInfo);
+ 
+@@ -939,7 +896,6 @@ void DownloadTargetDeterminer::ScheduleC
+            ? DownloadItem::TARGET_DISPOSITION_PROMPT
+            : DownloadItem::TARGET_DISPOSITION_OVERWRITE);
+   target_info->danger_type = danger_type_;
+-  target_info->danger_level = danger_level_;
+   target_info->intermediate_path = intermediate_path_;
+   target_info->mime_type = mime_type_;
+   target_info->is_filetype_handled_safely = is_filetype_handled_safely_;
+@@ -1027,38 +983,6 @@ bool DownloadTargetDeterminer::HasPrompt
                                  DownloadItem::TARGET_DISPOSITION_PROMPT);
  }
  
@@ -2505,7 +2594,38 @@
  using offline_items_collection::FailState;
  
  namespace {
-@@ -386,13 +384,6 @@ bool DownloadUIModel::ShouldPreferOpenin
+@@ -257,7 +255,7 @@ base::string16 DownloadUIModel::GetWarni
+ 
+   switch (GetDangerType()) {
+     case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_URL: {
+-      return l10n_util::GetStringUTF16(IDS_PROMPT_MALICIOUS_DOWNLOAD_URL);
++      break;
+     }
+     case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_FILE: {
+       if (IsExtensionDownload()) {
+@@ -270,19 +268,11 @@ base::string16 DownloadUIModel::GetWarni
+     }
+     case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_CONTENT:
+     case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST: {
+-      return l10n_util::GetStringFUTF16(IDS_PROMPT_MALICIOUS_DOWNLOAD_CONTENT,
+-                                        elided_filename);
++      break;
+     }
+     case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
+-      bool request_ap_verdicts = false;
+-#if defined(FULL_SAFE_BROWSING)
+-      request_ap_verdicts = safe_browsing::AdvancedProtectionStatusManager::
+-          RequestsAdvancedProtectionVerdicts(profile());
+-#endif
+       return l10n_util::GetStringFUTF16(
+-          request_ap_verdicts
+-              ? IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT_IN_ADVANCED_PROTECTION
+-              : IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT,
++          IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT,
+           elided_filename);
+     }
+     case download::DOWNLOAD_DANGER_TYPE_POTENTIALLY_UNWANTED: {
+@@ -386,13 +376,6 @@ bool DownloadUIModel::ShouldPreferOpenin
  
  void DownloadUIModel::SetShouldPreferOpeningInBrowser(bool preference) {}
  
@@ -2598,20 +2718,28 @@
  #if defined(OS_CHROMEOS)
 --- a/chrome/browser/extensions/api/enterprise_reporting_private/chrome_desktop_report_request_helper.cc
 +++ b/chrome/browser/extensions/api/enterprise_reporting_private/chrome_desktop_report_request_helper.cc
-@@ -200,14 +200,12 @@ GenerateChromeUserProfileReportRequest(c
-             profile_report.FindKey(kSafeBrowsingWarnings)) {
-       if (!count->is_int())
-         return nullptr;
--      request->set_safe_browsing_warnings(count->GetInt());
-     }
- 
-     if (const base::Value* count =
-             profile_report.FindKey(kSafeBrowsingWarningsClickThrough)) {
-       if (!count->is_int())
-         return nullptr;
--      request->set_safe_browsing_warnings_click_through(count->GetInt());
+@@ -195,22 +195,6 @@ GenerateChromeUserProfileReportRequest(c
      }
    }
+ 
+-  if (prefs->GetBoolean(enterprise_reporting::kReportSafeBrowsingData)) {
+-    if (const base::Value* count =
+-            profile_report.FindKey(kSafeBrowsingWarnings)) {
+-      if (!count->is_int())
+-        return nullptr;
+-      request->set_safe_browsing_warnings(count->GetInt());
+-    }
+-
+-    if (const base::Value* count =
+-            profile_report.FindKey(kSafeBrowsingWarningsClickThrough)) {
+-      if (!count->is_int())
+-        return nullptr;
+-      request->set_safe_browsing_warnings_click_through(count->GetInt());
+-    }
+-  }
+-
+   return request;
+ }
  
 --- a/chrome/browser/extensions/api/enterprise_reporting_private/chrome_desktop_report_request_helper_unittest.cc
 +++ b/chrome/browser/extensions/api/enterprise_reporting_private/chrome_desktop_report_request_helper_unittest.cc
@@ -2630,7 +2758,7 @@
  TEST_F(ChromeDesktopReportRequestGeneratorTest, DontReportPolicyData) {
 --- a/chrome/browser/extensions/api/enterprise_reporting_private/prefs.cc
 +++ b/chrome/browser/extensions/api/enterprise_reporting_private/prefs.cc
-@@ -22,9 +22,6 @@ const char kReportUserIDData[] = "enterp
+@@ -22,16 +22,12 @@ const char kReportUserIDData[] = "enterp
  const char kReportExtensionsAndPluginsData[] =
      "enterprise_reporting.report_extensions_and_plugins_data";
  
@@ -2640,6 +2768,13 @@
  void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
    registry->RegisterBooleanPref(kReportVersionData, true);
    registry->RegisterBooleanPref(kReportPolicyData, true);
+   registry->RegisterBooleanPref(kReportMachineIDData, true);
+   registry->RegisterBooleanPref(kReportUserIDData, true);
+   registry->RegisterBooleanPref(kReportExtensionsAndPluginsData, true);
+-  registry->RegisterBooleanPref(kReportSafeBrowsingData, false);
+   registry->RegisterBooleanPref(prefs::kCloudReportingEnabled, false);
+ }
+ 
 --- a/chrome/browser/extensions/api/enterprise_reporting_private/prefs.h
 +++ b/chrome/browser/extensions/api/enterprise_reporting_private/prefs.h
 @@ -27,9 +27,6 @@ extern const char kReportUserIDData[];
@@ -2717,15 +2852,15 @@
  namespace BeginInstallWithManifest3 =
 --- a/chrome/browser/extensions/blacklist.cc
 +++ b/chrome/browser/extensions/blacklist.cc
-@@ -19,7 +19,6 @@
+@@ -19,142 +19,15 @@
  #include "chrome/browser/browser_process.h"
  #include "chrome/browser/extensions/blacklist_factory.h"
  #include "chrome/browser/extensions/blacklist_state_fetcher.h"
 -#include "chrome/browser/safe_browsing/safe_browsing_service.h"
  #include "components/prefs/pref_service.h"
- #include "components/safe_browsing/db/util.h"
+-#include "components/safe_browsing/db/util.h"
  #include "content/public/browser/browser_task_traits.h"
-@@ -27,134 +26,9 @@
+ #include "content/public/browser/browser_thread.h"
  #include "extensions/browser/extension_prefs.h"
  
  using content::BrowserThread;
@@ -2860,7 +2995,7 @@
  Blacklist::Observer::Observer(Blacklist* blacklist) : blacklist_(blacklist) {
    blacklist_->AddObserver(this);
  }
-@@ -163,16 +37,6 @@ Blacklist::Observer::~Observer() {
+@@ -163,24 +36,7 @@ Blacklist::Observer::~Observer() {
    blacklist_->RemoveObserver(this);
  }
  
@@ -2875,9 +3010,23 @@
 -}
 -
  Blacklist::Blacklist(ExtensionPrefs* prefs) {
-   auto& lazy_database_manager = g_database_manager.Get();
-   // Using base::Unretained is safe because when this object goes away, the
-@@ -201,14 +65,6 @@ void Blacklist::GetBlacklistedIDs(const
+-  auto& lazy_database_manager = g_database_manager.Get();
+-  // Using base::Unretained is safe because when this object goes away, the
+-  // subscription will automatically be destroyed.
+-  database_changed_subscription_ =
+-      lazy_database_manager.RegisterDatabaseChangedCallback(base::BindRepeating(
+-          &Blacklist::ObserveNewDatabase, base::Unretained(this)));
+-
+   ObserveNewDatabase();
+ }
+ 
+@@ -196,25 +52,15 @@ void Blacklist::GetBlacklistedIDs(const
+                                   const GetBlacklistedIDsCallback& callback) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+ 
+-  if (ids.empty() || !GetDatabaseManager().get()) {
++  if (ids.empty()) {
+     base::ThreadTaskRunnerHandle::Get()->PostTask(
          FROM_HERE, base::BindOnce(callback, BlacklistStateMap()));
      return;
    }
@@ -2892,7 +3041,21 @@
  }
  
  void Blacklist::GetMalwareIDs(const std::set<std::string>& ids,
-@@ -339,17 +195,6 @@ void Blacklist::RemoveObserver(Observer*
+                               const GetMalwareIDsCallback& callback) {
+-  GetBlacklistedIDs(ids, base::Bind(&GetMalwareFromBlacklistStateMap,
+-                                    callback));
+ }
+ 
+ 
+@@ -222,7 +68,6 @@ void Blacklist::IsBlacklisted(const std:
+                               const IsBlacklistedCallback& callback) {
+   std::set<std::string> check;
+   check.insert(extension_id);
+-  GetBlacklistedIDs(check, base::Bind(&CheckOneExtensionState, callback));
+ }
+ 
+ void Blacklist::GetBlacklistStateForIDs(
+@@ -339,29 +184,8 @@ void Blacklist::RemoveObserver(Observer*
    observers_.RemoveObserver(observer);
  }
  
@@ -2908,8 +3071,21 @@
 -}
 -
  void Blacklist::ObserveNewDatabase() {
-   auto database_manager = GetDatabaseManager();
-   if (database_manager.get()) {
+-  auto database_manager = GetDatabaseManager();
+-  if (database_manager.get()) {
+-    // Using base::Unretained is safe because when this object goes away, the
+-    // subscription to the callback list will automatically be destroyed.
+-    database_updated_subscription_ =
+-        database_manager.get()->RegisterDatabaseUpdatedCallback(
+-            base::BindRepeating(&Blacklist::NotifyObservers,
+-                                base::Unretained(this)));
+-  } else {
+-    database_updated_subscription_.reset();
+-  }
++  database_updated_subscription_.reset();
+ }
+ 
+ void Blacklist::NotifyObservers() {
 --- a/chrome/browser/extensions/blacklist.h
 +++ b/chrome/browser/extensions/blacklist.h
 @@ -18,7 +18,6 @@
@@ -2967,6 +3143,86 @@
  #include "content/public/browser/browser_thread.h"
  #include "net/base/escape.h"
  #include "net/traffic_annotation/network_traffic_annotation.h"
+@@ -38,57 +35,6 @@ void BlacklistStateFetcher::Request(cons
+ 
+ void BlacklistStateFetcher::SendRequest(const std::string& id) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-
+-  ClientCRXListInfoRequest request;
+-  request.set_id(id);
+-  std::string request_str;
+-  request.SerializeToString(&request_str);
+-
+-  GURL request_url = GURL();
+-  net::NetworkTrafficAnnotationTag traffic_annotation =
+-      net::DefineNetworkTrafficAnnotation("extension_blacklist", R"(
+-        semantics {
+-          sender: "Extension Blacklist"
+-          description:
+-            "Chromium protects the users from malicious extensions by checking "
+-            "extensions that are being installed or have been installed "
+-            "against a list of known malwares. Chromium sends the identifiers "
+-            "of extensions to Google and Google responds with whether it "
+-            "believes each extension is malware or not. Only extensions that "
+-            "match the safe browsing blacklist can trigger this request."
+-          trigger:
+-            "When extensions are being installed and at startup when existing "
+-            "extensions are scanned."
+-          data: "The identifier of the installed extension."
+-          destination: GOOGLE_OWNED_SERVICE
+-        }
+-        policy {
+-          cookies_allowed: YES
+-          cookies_store: "Safe Browsing cookies store"
+-          setting:
+-            "Users can enable or disable this feature by toggling 'Protect you "
+-            "and your device from dangerous sites' in Chromium settings under "
+-            "Privacy. This feature is enabled by default."
+-          chrome_policy {
+-            SafeBrowsingEnabled {
+-              policy_options {mode: MANDATORY}
+-              SafeBrowsingEnabled: false
+-            }
+-          }
+-        })");
+-  auto resource_request = std::make_unique<network::ResourceRequest>();
+-  resource_request->url = request_url;
+-  resource_request->method = "POST";
+-  std::unique_ptr<network::SimpleURLLoader> fetcher_ptr =
+-      network::SimpleURLLoader::Create(std::move(resource_request),
+-                                       traffic_annotation);
+-  auto* fetcher = fetcher_ptr.get();
+-  fetcher->AttachStringForUpload(request_str, "application/octet-stream");
+-  requests_[fetcher] = {std::move(fetcher_ptr), id};
+-  fetcher->DownloadToStringOfUnboundedSizeUntilCrashAndDie(
+-      url_loader_factory_.get(),
+-      base::BindOnce(&BlacklistStateFetcher::OnURLLoaderComplete,
+-                     base::Unretained(this), fetcher));
+ }
+ 
+ void BlacklistStateFetcher::OnURLLoaderComplete(
+@@ -126,12 +72,7 @@ void BlacklistStateFetcher::OnURLLoaderC
+ 
+   BlacklistState state;
+   if (net_error == net::OK && response_code == 200) {
+-    ClientCRXListInfoResponse response;
+-    if (response.ParseFromString(response_body)) {
+-      state = static_cast<BlacklistState>(response.verdict());
+-    } else {
+-      state = BLACKLISTED_UNKNOWN;
+-    }
++    state = BLACKLISTED_UNKNOWN;
+   } else {
+     if (net_error != net::OK) {
+       VLOG(1) << "Blacklist request for: " << id
+@@ -140,7 +81,6 @@ void BlacklistStateFetcher::OnURLLoaderC
+       VLOG(1) << "Blacklist request for: " << id
+               << " failed with error: " << response_code;
+     }
+-
+     state = BLACKLISTED_UNKNOWN;
+   }
+ 
 --- a/chrome/browser/extensions/blacklist_state_fetcher.h
 +++ b/chrome/browser/extensions/blacklist_state_fetcher.h
 @@ -13,7 +13,6 @@
@@ -2999,7 +3255,7 @@
  #include "content/public/browser/storage_partition.h"
 --- a/chrome/browser/interstitials/enterprise_util.cc
 +++ b/chrome/browser/interstitials/enterprise_util.cc
-@@ -4,8 +4,6 @@
+@@ -4,44 +4,15 @@
  
  #include "chrome/browser/interstitials/enterprise_util.h"
  
@@ -3008,10 +3264,55 @@
  #include "chrome/browser/profiles/profile.h"
  #include "content/public/browser/web_contents.h"
  #include "extensions/buildflags/buildflags.h"
-@@ -58,39 +56,3 @@ void MaybeTriggerSecurityInterstitialPro
-                                                 net_error_code);
- #endif
+ 
+-namespace {
+-
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
+-extensions::SafeBrowsingPrivateEventRouter* GetEventRouter(
+-    content::WebContents* web_contents) {
+-  // |web_contents| can be null in tests.
+-  if (!web_contents)
+-    return nullptr;
+-
+-  content::BrowserContext* browser_context = web_contents->GetBrowserContext();
+-  if (browser_context->IsOffTheRecord())
+-    return nullptr;
+-
+-  return extensions::SafeBrowsingPrivateEventRouterFactory::GetForProfile(
+-      browser_context);
+-}
+-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+-
+-}  // namespace
+-
+ void MaybeTriggerSecurityInterstitialShownEvent(
+     content::WebContents* web_contents,
+     const GURL& page_url,
+     const std::string& reason,
+     int net_error_code) {
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
+-  extensions::SafeBrowsingPrivateEventRouter* event_router =
+-      GetEventRouter(web_contents);
+-  if (!event_router)
+-    return;
+-  event_router->OnSecurityInterstitialShown(page_url, reason, net_error_code);
+-#endif
  }
+ 
+ void MaybeTriggerSecurityInterstitialProceededEvent(
+@@ -49,48 +20,4 @@ void MaybeTriggerSecurityInterstitialPro
+     const GURL& page_url,
+     const std::string& reason,
+     int net_error_code) {
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
+-  extensions::SafeBrowsingPrivateEventRouter* event_router =
+-      GetEventRouter(web_contents);
+-  if (!event_router)
+-    return;
+-  event_router->OnSecurityInterstitialProceeded(page_url, reason,
+-                                                net_error_code);
+-#endif
+-}
 -
 -std::string GetThreatTypeStringForInterstitial(
 -    safe_browsing::SBThreatType threat_type) {
@@ -3047,7 +3348,7 @@
 -      break;
 -  }
 -  return std::string();
--}
+ }
 --- a/chrome/browser/interstitials/enterprise_util.h
 +++ b/chrome/browser/interstitials/enterprise_util.h
 @@ -5,8 +5,6 @@
@@ -3324,17 +3625,22 @@
    { key::kUrlKeyedAnonymizedDataCollectionEnabled,
      unified_consent::prefs::kUrlKeyedAnonymizedDataCollectionEnabled,
      base::Value::Type::BOOLEAN },
-@@ -310,9 +303,6 @@ const PolicyToPreferenceMapEntry kSimple
-   { key::kPasswordProtectionWarningTrigger,
-     prefs::kPasswordProtectionWarningTrigger,
-     base::Value::Type::INTEGER},
+@@ -307,25 +300,9 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kAllowCrossOriginAuthPrompt,
+     prefs::kAllowCrossOriginAuthPrompt,
+     base::Value::Type::BOOLEAN },
+-  { key::kPasswordProtectionWarningTrigger,
+-    prefs::kPasswordProtectionWarningTrigger,
+-    base::Value::Type::INTEGER},
 -  { key::kSafeBrowsingWhitelistDomains,
 -    prefs::kSafeBrowsingWhitelistDomains,
 -    base::Value::Type::LIST},
-   { key::kPasswordProtectionLoginURLs,
-     prefs::kPasswordProtectionLoginURLs,
-     base::Value::Type::LIST},
-@@ -322,10 +312,6 @@ const PolicyToPreferenceMapEntry kSimple
+-  { key::kPasswordProtectionLoginURLs,
+-    prefs::kPasswordProtectionLoginURLs,
+-    base::Value::Type::LIST},
+-  { key::kPasswordProtectionChangePasswordURL,
+-    prefs::kPasswordProtectionChangePasswordURL,
+-    base::Value::Type::STRING},
    { key::kSafeSitesFilterBehavior,
      policy_prefs::kSafeSitesFilterBehavior,
      base::Value::Type::INTEGER},
@@ -3345,7 +3651,7 @@
  #if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
    { key::kAuthNegotiateDelegateByKdcPolicy,
      prefs::kAuthNegotiateDelegateByKdcPolicy,
-@@ -422,7 +408,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -422,7 +399,6 @@ const PolicyToPreferenceMapEntry kSimple
    { key::kImportAutofillFormData,
      prefs::kImportDialogAutofillFormData,
      base::Value::Type::BOOLEAN },
@@ -3353,7 +3659,7 @@
    { key::kMaxConnectionsPerProxy,
      prefs::kMaxConnectionsPerProxy,
      base::Value::Type::INTEGER },
-@@ -438,9 +423,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -438,9 +414,6 @@ const PolicyToPreferenceMapEntry kSimple
    { key::kDefaultMediaStreamSetting,
      prefs::kManagedDefaultMediaStreamSetting,
      base::Value::Type::INTEGER },
@@ -3363,7 +3669,7 @@
    { key::kSSLErrorOverrideAllowed,
      prefs::kSSLErrorOverrideAllowed,
      base::Value::Type::BOOLEAN },
-@@ -818,9 +800,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -818,9 +791,6 @@ const PolicyToPreferenceMapEntry kSimple
    { key::kReportExtensionsAndPluginsData,
      extensions::enterprise_reporting::kReportExtensionsAndPluginsData,
      base::Value::Type::BOOLEAN },
@@ -3373,7 +3679,7 @@
  #endif  // !defined(OS_CHROMEOS) && BUILDFLAG(ENABLE_EXTENSIONS)
  
  #if !defined(OS_MACOSX) && !defined(OS_CHROMEOS)
-@@ -1269,22 +1248,6 @@ std::unique_ptr<ConfigurationPolicyHandl
+@@ -1269,22 +1239,6 @@ std::unique_ptr<ConfigurationPolicyHandl
        SimpleSchemaValidatingPolicyHandler::RECOMMENDED_ALLOWED,
        SimpleSchemaValidatingPolicyHandler::MANDATORY_PROHIBITED));
  
@@ -3596,6 +3902,46 @@
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
  #include "chrome/browser/ui/webui/settings/incompatible_applications_handler_win.h"
  #include "chrome/browser/win/conflicts/incompatible_applications_updater.h"
+@@ -148,11 +145,6 @@
+ #include "chrome/browser/ui/webui/settings/printing_handler.h"
+ #endif
+ 
+-#if defined(FULL_SAFE_BROWSING)
+-#include "chrome/browser/safe_browsing/chrome_password_protection_service.h"
+-#include "chrome/browser/ui/webui/settings/change_password_handler.h"
+-#endif
+-
+ namespace settings {
+ 
+ namespace {
+@@ -253,10 +245,6 @@ SettingsUI::SettingsUI(content::WebUI* w
+   AddSettingsPageUIHandler(std::make_unique<PrintingHandler>());
+ #endif
+ 
+-#if defined(OS_WIN)
+-  AddSettingsPageUIHandler(std::make_unique<ChromeCleanupHandler>(profile));
+-#endif  // defined(OS_WIN)
+-
+ #if defined(OS_WIN) && BUILDFLAG(GOOGLE_CHROME_BRANDING)
+   bool has_incompatible_applications =
+       IncompatibleApplicationsUpdater::HasCachedApplications();
+@@ -270,16 +258,6 @@ SettingsUI::SettingsUI(content::WebUI* w
+ #endif  // OS_WIN && BUILDFLAG(GOOGLE_CHROME_BRANDING)
+ 
+   bool password_protection_available = false;
+-#if defined(FULL_SAFE_BROWSING)
+-  safe_browsing::ChromePasswordProtectionService* password_protection =
+-      safe_browsing::ChromePasswordProtectionService::
+-          GetPasswordProtectionService(profile);
+-  password_protection_available = !!password_protection;
+-  if (password_protection) {
+-    AddSettingsPageUIHandler(
+-        std::make_unique<ChangePasswordHandler>(profile, password_protection));
+-  }
+-#endif
+   html_source->AddBoolean("passwordProtectionAvailable",
+                           password_protection_available);
+ 
 --- a/chrome/browser/win/conflicts/BUILD.gn
 +++ b/chrome/browser/win/conflicts/BUILD.gn
 @@ -31,7 +31,6 @@ source_set("module_info") {
@@ -4054,18 +4400,22 @@
    if (enable_app_list) {
      sources += [
        "../browser/ui/app_list/app_context_menu_unittest.cc",
-@@ -5148,9 +4974,7 @@ if (!is_android) {
-   import("//third_party/protobuf/proto_library.gni")
+@@ -5145,14 +4971,6 @@ if (!is_android) {
+     }
+   }
  
-   proto_library("test_proto") {
+-  import("//third_party/protobuf/proto_library.gni")
+-
+-  proto_library("test_proto") {
 -    sources = [
 -      "../common/safe_browsing/ipc_protobuf_message_test.proto",
 -    ]
-+    sources = []
-   }
- 
+-  }
+-
    if (is_chromeos) {
-@@ -6245,27 +6069,6 @@ if (!is_android && !is_fuchsia) {
+     assert(enable_app_list)
+     assert(enable_extensions)
+@@ -6245,27 +6063,6 @@ if (!is_android && !is_fuchsia) {
    }
  }
  
@@ -4824,3 +5174,702 @@
      "//components/spellcheck/common",
      "//components/subresource_filter/content/common",
      "//components/tracing",
+--- a/chrome/app/chrome_content_renderer_overlay_manifest.cc
++++ b/chrome/app/chrome_content_renderer_overlay_manifest.cc
+@@ -12,7 +12,6 @@
+ #include "chrome/common/search.mojom.h"
+ #include "components/autofill/content/common/mojom/autofill_agent.mojom.h"
+ #include "components/dom_distiller/content/common/mojom/distiller_page_notifier_service.mojom.h"
+-#include "components/safe_browsing/common/safe_browsing.mojom.h"
+ #include "components/services/heap_profiling/public/mojom/heap_profiling_client.mojom.h"
+ #include "components/subresource_filter/content/mojom/subresource_filter_agent.mojom.h"
+ #include "extensions/buildflags/buildflags.h"
+@@ -67,10 +66,6 @@ const service_manager::Manifest& GetChro
+                 extensions::mojom::AppWindow,
+                 extensions::mojom::MimeHandlerViewContainerManager,
+ #endif  // TODO: need gated include back
+-                safe_browsing::mojom::ThreatReporter,
+-#if defined(FULL_SAFE_BROWSING)
+-                safe_browsing::mojom::PhishingDetector,
+-#endif
+ #if defined(OS_MACOSX)
+                 spellcheck::mojom::SpellCheckPanel,
+ #endif
+--- a/chrome/browser/download/download_target_info.h
++++ b/chrome/browser/download/download_target_info.h
+@@ -8,7 +8,6 @@
+ #include <string>
+ 
+ #include "base/files/file_path.h"
+-#include "chrome/common/safe_browsing/download_file_types.pb.h"
+ #include "components/download/public/common/download_danger_type.h"
+ #include "components/download/public/common/download_interrupt_reasons.h"
+ #include "components/download/public/common/download_item.h"
+@@ -32,32 +31,6 @@ struct DownloadTargetInfo {
+   // Danger type of the download.
+   download::DownloadDangerType danger_type;
+ 
+-  // The danger type of the download could be set to MAYBE_DANGEROUS_CONTENT if
+-  // the file type is handled by SafeBrowsing. However, if the SafeBrowsing
+-  // service is unable to verify whether the file is safe or not, we are on our
+-  // own. The value of |danger_level| indicates whether the download should be
+-  // considered dangerous if SafeBrowsing returns an unknown verdict.
+-  //
+-  // Note that some downloads (e.g. "Save link as" on a link to a binary) would
+-  // not be considered 'Dangerous' even if SafeBrowsing came back with an
+-  // unknown verdict. So we can't always show a warning when SafeBrowsing fails.
+-  //
+-  // The value of |danger_level| should be interpreted as follows:
+-  //
+-  //   NOT_DANGEROUS : Unless flagged by SafeBrowsing, the file should be
+-  //       considered safe.
+-  //
+-  //   ALLOW_ON_USER_GESTURE : If SafeBrowsing claims the file is safe, then the
+-  //       file is safe. An UNKOWN verdict results in the file being marked as
+-  //       DANGEROUS_FILE.
+-  //
+-  //   DANGEROUS : This type of file shouldn't be allowed to download witout any
+-  //       user action. Hence, if SafeBrowsing marks the file as SAFE, or
+-  //       UNKONWN, the file will still be conisdered a DANGEROUS_FILE. However,
+-  //       SafeBrowsing may flag the file as being malicious, in which case the
+-  //       malicious classification should take precedence.
+-  safe_browsing::DownloadFileType::DangerLevel danger_level;
+-
+   // Suggested intermediate path. The downloaded bytes should be written to this
+   // path until all the bytes are available and the user has accepted a
+   // dangerous download. At that point, the download can be renamed to
+--- a/chrome/browser/download/download_target_info.cc
++++ b/chrome/browser/download/download_target_info.cc
+@@ -4,12 +4,9 @@
+ 
+ #include "chrome/browser/download/download_target_info.h"
+ 
+-#include "chrome/common/safe_browsing/file_type_policies.h"
+-
+ DownloadTargetInfo::DownloadTargetInfo()
+     : target_disposition(download::DownloadItem::TARGET_DISPOSITION_OVERWRITE),
+       danger_type(download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS),
+-      danger_level(safe_browsing::DownloadFileType::NOT_DANGEROUS),
+       is_filetype_handled_safely(false),
+       result(download::DOWNLOAD_INTERRUPT_REASON_NONE) {}
+ 
+--- a/chrome/browser/component_updater/file_type_policies_component_installer.cc
++++ b/chrome/browser/component_updater/file_type_policies_component_installer.cc
+@@ -18,7 +18,6 @@
+ #include "base/stl_util.h"
+ #include "base/task/post_task.h"
+ #include "base/version.h"
+-#include "chrome/common/safe_browsing/file_type_policies.h"
+ #include "components/component_updater/component_updater_paths.h"
+ 
+ using component_updater::ComponentUpdateService;
+--- a/chrome/browser/ssl/security_state_tab_helper.cc
++++ b/chrome/browser/ssl/security_state_tab_helper.cc
+@@ -15,8 +15,6 @@
+ #include "build/build_config.h"
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/profiles/profile.h"
+-#include "chrome/browser/safe_browsing/safe_browsing_service.h"
+-#include "chrome/browser/safe_browsing/ui_manager.h"
+ #include "chrome/common/secure_origin_whitelist.h"
+ #include "components/omnibox/browser/omnibox_field_trial.h"
+ #include "components/omnibox/common/omnibox_features.h"
+@@ -42,10 +40,6 @@
+ #include "chrome/browser/chromeos/policy/policy_cert_service_factory.h"
+ #endif  // defined(OS_CHROMEOS)
+ 
+-#if defined(FULL_SAFE_BROWSING)
+-#include "chrome/browser/safe_browsing/chrome_password_protection_service.h"
+-#endif
+-
+ namespace {
+ 
+ void RecordSecurityLevel(
+@@ -65,7 +59,6 @@ void RecordSecurityLevel(
+ }  // namespace
+ 
+ using password_manager::metrics_util::PasswordType;
+-using safe_browsing::SafeBrowsingUIManager;
+ 
+ SecurityStateTabHelper::SecurityStateTabHelper(
+     content::WebContents* web_contents)
+--- a/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
++++ b/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
+@@ -15,16 +15,13 @@
+ #include "chrome/browser/content_settings/tab_specific_content_settings.h"
+ #include "chrome/browser/infobars/infobar_service.h"
+ #include "chrome/browser/profiles/profile.h"
+-#include "chrome/browser/safe_browsing/safe_browsing_service.h"
+ #include "chrome/browser/subresource_filter/subresource_filter_content_settings_manager.h"
+ #include "chrome/browser/subresource_filter/subresource_filter_profile_context.h"
+ #include "chrome/browser/subresource_filter/subresource_filter_profile_context_factory.h"
+ #include "components/content_settings/core/browser/host_content_settings_map.h"
+ #include "components/content_settings/core/common/content_settings_types.h"
+-#include "components/safe_browsing/db/database_manager.h"
+ #include "components/subresource_filter/content/browser/content_subresource_filter_throttle_manager.h"
+ #include "components/subresource_filter/content/browser/ruleset_service.h"
+-#include "components/subresource_filter/content/browser/subresource_filter_safe_browsing_activation_throttle.h"
+ #include "components/subresource_filter/core/browser/subresource_filter_features.h"
+ #include "components/subresource_filter/core/common/activation_decision.h"
+ #include "components/subresource_filter/core/common/activation_scope.h"
+@@ -46,10 +43,7 @@ ChromeSubresourceFilterClient::ChromeSub
+           Profile::FromBrowserContext(web_contents->GetBrowserContext()));
+   settings_manager_ = context->settings_manager();
+ 
+-  subresource_filter::RulesetService* ruleset_service =
+-      g_browser_process->subresource_filter_ruleset_service();
+-  subresource_filter::VerifiedRulesetDealer::Handle* dealer =
+-      ruleset_service ? ruleset_service->GetRulesetDealer() : nullptr;
++  subresource_filter::VerifiedRulesetDealer::Handle* dealer = nullptr;
+   throttle_manager_ = std::make_unique<
+       subresource_filter::ContentSubresourceFilterThrottleManager>(
+       this, dealer, web_contents);
+--- a/chrome/browser/ui/webui/interstitials/interstitial_ui.cc
++++ b/chrome/browser/ui/webui/interstitials/interstitial_ui.cc
+@@ -14,17 +14,12 @@
+ #include "chrome/browser/lookalikes/lookalike_url_controller_client.h"
+ #include "chrome/browser/lookalikes/lookalike_url_interstitial_page.h"
+ #include "chrome/browser/profiles/profile.h"
+-#include "chrome/browser/safe_browsing/safe_browsing_blocking_page.h"
+-#include "chrome/browser/safe_browsing/safe_browsing_service.h"
+-#include "chrome/browser/safe_browsing/test_safe_browsing_blocking_page_quiet.h"
+-#include "chrome/browser/safe_browsing/ui_manager.h"
+ #include "chrome/browser/ssl/bad_clock_blocking_page.h"
+ #include "chrome/browser/ssl/mitm_software_blocking_page.h"
+ #include "chrome/browser/ssl/ssl_blocking_page.h"
+ #include "chrome/common/buildflags.h"
+ #include "chrome/common/url_constants.h"
+ #include "components/grit/components_resources.h"
+-#include "components/safe_browsing/db/database_manager.h"
+ #include "components/security_interstitials/content/origin_policy_ui.h"
+ #include "components/security_interstitials/core/ssl_error_ui.h"
+ #include "components/supervised_user_error_page/supervised_user_error_page.h"
+@@ -49,8 +44,6 @@
+ #include "chrome/browser/ssl/captive_portal_blocking_page.h"
+ #endif
+ 
+-using security_interstitials::TestSafeBrowsingBlockingPageQuiet;
+-
+ namespace {
+ 
+ // NSS requires that serial numbers be unique even for the same issuer;
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -44,7 +44,6 @@
+ #include "components/omnibox/common/omnibox_features.h"
+ #include "components/password_manager/core/browser/manage_passwords_referrer.h"
+ #include "components/password_manager/core/common/password_manager_features.h"
+-#include "components/safe_browsing/common/safe_browsing_prefs.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "components/subresource_filter/core/browser/subresource_filter_features.h"
+@@ -98,7 +97,6 @@
+ #endif
+ 
+ #if defined(OS_WIN)
+-#include "chrome/browser/safe_browsing/chrome_cleaner/srt_field_trial_win.h"
+ #include "device/fido/win/webauthn_api.h"
+ 
+ #if defined(GOOGLE_CHROME_BUILD)
+@@ -2354,14 +2352,6 @@ void AddPrivacyStrings(content::WebUIDat
+       {"clearBrowsingData", IDS_SETTINGS_CLEAR_BROWSING_DATA},
+       {"clearBrowsingDataDescription", IDS_SETTINGS_CLEAR_DATA_DESCRIPTION},
+       {"titleAndCount", IDS_SETTINGS_TITLE_AND_COUNT},
+-      {"safeBrowsingEnableExtendedReporting",
+-       IDS_SETTINGS_SAFEBROWSING_ENABLE_REPORTING},
+-      {"safeBrowsingEnableExtendedReportingDesc",
+-       IDS_SETTINGS_SAFEBROWSING_ENABLE_REPORTING_DESC},
+-      {"safeBrowsingEnableProtection",
+-       IDS_SETTINGS_SAFEBROWSING_ENABLEPROTECTION},
+-      {"safeBrowsingEnableProtectionDesc",
+-       IDS_SETTINGS_SAFEBROWSING_ENABLEPROTECTION_DESC},
+       {"syncAndGoogleServicesPrivacyDescription",
+        IDS_SETTINGS_SYNC_AND_GOOGLE_SERVICES_PRIVACY_DESC_UNIFIED_CONSENT},
+       {"urlKeyedAnonymizedDataCollection",
+@@ -2938,11 +2928,6 @@ void AddSiteSettingsStrings(content::Web
+                           base::size(kSensorsLocalizedStrings));
+ 
+   html_source->AddBoolean(
+-      "enableSafeBrowsingSubresourceFilter",
+-      base::FeatureList::IsEnabled(
+-          subresource_filter::kSafeBrowsingSubresourceFilter));
+-
+-  html_source->AddBoolean(
+       "enableBlockAutoplayContentSetting",
+       base::FeatureList::IsEnabled(media::kAutoplayDisableSettings));
+ 
+--- a/chrome/browser/ui/tab_helpers.cc
++++ b/chrome/browser/ui/tab_helpers.cc
+@@ -48,8 +48,6 @@
+ #include "chrome/browser/previews/resource_loading_hints/resource_loading_hints_web_contents_observer.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/resource_coordinator/tab_helper.h"
+-#include "chrome/browser/safe_browsing/safe_browsing_navigation_observer.h"
+-#include "chrome/browser/safe_browsing/trigger_creator.h"
+ #include "chrome/browser/sessions/session_tab_helper.h"
+ #include "chrome/browser/ssl/connection_help_tab_helper.h"
+ #include "chrome/browser/ssl/security_state_tab_helper.h"
+@@ -200,10 +198,6 @@ void TabHelpers::AttachTabHelpers(WebCon
+   ChromePasswordManagerClient::CreateForWebContentsWithAutofillClient(
+       web_contents,
+       autofill::ChromeAutofillClient::FromWebContents(web_contents));
+-  if (base::FeatureList::IsEnabled(
+-          subresource_filter::kSafeBrowsingSubresourceFilter)) {
+-    ChromeSubresourceFilterClient::CreateForWebContents(web_contents);
+-  }
+   ChromeTranslateClient::CreateForWebContents(web_contents);
+   ClientHintsObserver::CreateForWebContents(web_contents);
+   ConnectionHelpTabHelper::CreateForWebContents(web_contents);
+--- a/chrome/browser/ui/views/download/download_item_view.cc
++++ b/chrome/browser/ui/views/download/download_item_view.cc
+@@ -29,10 +29,6 @@
+ #include "chrome/browser/download/download_stats.h"
+ #include "chrome/browser/download/drag_download_item.h"
+ #include "chrome/browser/profiles/profile.h"
+-#include "chrome/browser/safe_browsing/advanced_protection_status_manager.h"
+-#include "chrome/browser/safe_browsing/download_protection/download_feedback_service.h"
+-#include "chrome/browser/safe_browsing/download_protection/download_protection_service.h"
+-#include "chrome/browser/safe_browsing/safe_browsing_service.h"
+ #include "chrome/browser/themes/theme_properties.h"
+ #include "chrome/browser/ui/views/download/download_shelf_context_menu_view.h"
+ #include "chrome/browser/ui/views/download/download_shelf_view.h"
+@@ -41,7 +37,6 @@
+ #include "chrome/grit/generated_resources.h"
+ #include "components/download/public/common/download_danger_type.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/common/safe_browsing_prefs.h"
+ #include "components/url_formatter/elide_url.h"
+ #include "components/vector_icons/vector_icons.h"
+ #include "content/public/browser/download_item_utils.h"
+@@ -713,26 +708,8 @@ void DownloadItemView::OpenDownload() {
+ 
+ bool DownloadItemView::SubmitDownloadToFeedbackService(
+     DownloadCommands::Command download_command) {
+-#if defined(FULL_SAFE_BROWSING)
+-  safe_browsing::SafeBrowsingService* sb_service =
+-      g_browser_process->safe_browsing_service();
+-  if (!sb_service)
+-    return false;
+-  safe_browsing::DownloadProtectionService* download_protection_service =
+-      sb_service->download_protection_service();
+-  if (!download_protection_service)
+-    return false;
+-  // TODO(shaktisahu): Enable feedback service for offline item.
+-  if (model_->download()) {
+-    return download_protection_service->MaybeBeginFeedbackForDownload(
+-        shelf_->browser()->profile(), model_->download(), download_command);
+-  }
+-  // WARNING: we are deleted at this point.  Don't access 'this'.
+-  return true;
+-#else
+   NOTREACHED();
+   return false;
+-#endif
+ }
+ 
+ void DownloadItemView::LoadIcon() {
+@@ -904,12 +881,6 @@ void DownloadItemView::ShowWarningDialog
+   time_download_warning_shown_ = base::Time::Now();
+   download::DownloadDangerType danger_type = model_->GetDangerType();
+   RecordDangerousDownloadWarningShown(danger_type);
+-#if defined(FULL_SAFE_BROWSING)
+-  if (model_->ShouldAllowDownloadFeedback()) {
+-    safe_browsing::DownloadFeedbackService::RecordEligibleDownloadShown(
+-        danger_type);
+-  }
+-#endif
+   SetMode(model_->MightBeMalicious() ? MALICIOUS_MODE : DANGEROUS_MODE);
+ 
+   dropdown_state_ = NORMAL;
+@@ -948,14 +919,8 @@ gfx::ImageSkia DownloadItemView::GetWarn
+                                    gfx::kGoogleRed700);
+ 
+     case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT:
+-      if (safe_browsing::AdvancedProtectionStatusManager::
+-              RequestsAdvancedProtectionVerdicts(model()->profile())) {
+-        return gfx::CreateVectorIcon(vector_icons::kErrorIcon, kErrorIconSize,
+-                                     gfx::kGoogleYellow500);
+-      } else {
+-        return gfx::CreateVectorIcon(vector_icons::kWarningIcon,
+-                                     kWarningIconSize, gfx::kGoogleRed700);
+-      }
++      return gfx::CreateVectorIcon(vector_icons::kErrorIcon, kErrorIconSize,
++                                   gfx::kGoogleYellow500);
+     case download::DOWNLOAD_DANGER_TYPE_BLOCKED_PASSWORD_PROTECTED:
+     case download::DOWNLOAD_DANGER_TYPE_ASYNC_SCANNING:
+     case download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS:
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -139,7 +139,6 @@
+ #include "components/omnibox/browser/omnibox_popup_view.h"
+ #include "components/omnibox/browser/omnibox_view.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/password_protection/metrics_util.h"
+ #include "components/sessions/core/tab_restore_service.h"
+ #include "components/translate/core/browser/language_state.h"
+ #include "components/version_info/channel.h"
+--- a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
++++ b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
+@@ -81,8 +81,6 @@
+ #include "components/history/core/browser/history_types.h"
+ #include "components/nacl/common/buildflags.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/web_ui/constants.h"
+-#include "components/safe_browsing/web_ui/safe_browsing_ui.h"
+ #include "components/security_interstitials/content/connection_help_ui.h"
+ #include "components/security_interstitials/content/urls.h"
+ #include "content/public/browser/web_contents.h"
+@@ -231,10 +229,6 @@
+ #include "extensions/common/manifest.h"
+ #endif
+ 
+-#if defined(FULL_SAFE_BROWSING)
+-#include "chrome/browser/ui/webui/reset_password/reset_password_ui.h"
+-#endif
+-
+ #if BUILDFLAG(ENABLE_SUPERVISED_USERS)
+ #include "chrome/browser/ui/webui/supervised_user_internals_ui.h"
+ #endif
+@@ -400,8 +394,6 @@ WebUIFactoryFunction GetWebUIFactoryFunc
+     return &NewWebUI<PredictorsUI>;
+   if (url.host_piece() == chrome::kChromeUIQuotaInternalsHost)
+     return &NewWebUI<QuotaInternalsUI>;
+-  if (url.host_piece() == safe_browsing::kChromeUISafeBrowsingHost)
+-    return &NewWebUI<safe_browsing::SafeBrowsingUI>;
+   if (url.host_piece() == chrome::kChromeUISignInInternalsHost)
+     return &NewWebUI<SignInInternalsUI>;
+   if (url.host_piece() == chrome::kChromeUISuggestionsHost)
+@@ -713,12 +705,6 @@ WebUIFactoryFunction GetWebUIFactoryFunc
+     return &NewWebUI<MediaEngagementUI>;
+   }
+ 
+-#if defined(FULL_SAFE_BROWSING)
+-  if (url.host_piece() == chrome::kChromeUIResetPasswordHost) {
+-    return &NewWebUI<ResetPasswordUI>;
+-  }
+-#endif
+-
+ #if BUILDFLAG(ENABLE_SUPERVISED_USERS)
+   if (url.host_piece() == chrome::kChromeUISupervisedUserInternalsHost)
+     return &NewWebUI<SupervisedUserInternalsUI>;
+--- a/chrome/browser/ui/views/frame/browser_window_factory.cc
++++ b/chrome/browser/ui/views/frame/browser_window_factory.cc
+@@ -8,7 +8,6 @@
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/frame/native_browser_frame_factory.h"
+ #include "chrome/grit/chromium_strings.h"
+-#include "components/safe_browsing/password_protection/metrics_util.h"
+ #if defined(USE_AURA)
+ #include "ui/aura/client/aura_constants.h"
+ #include "ui/aura/window.h"
+--- a/chrome/renderer/websocket_handshake_throttle_provider_impl.h
++++ b/chrome/renderer/websocket_handshake_throttle_provider_impl.h
+@@ -9,7 +9,6 @@
+ 
+ #include "base/macros.h"
+ #include "base/threading/thread_checker.h"
+-#include "components/safe_browsing/common/safe_browsing.mojom.h"
+ #include "content/public/renderer/websocket_handshake_throttle_provider.h"
+ 
+ // This must be constructed on the render thread, and then used and destructed
+@@ -33,9 +32,6 @@ class WebSocketHandshakeThrottleProvider
+   WebSocketHandshakeThrottleProviderImpl(
+       const WebSocketHandshakeThrottleProviderImpl& other);
+ 
+-  safe_browsing::mojom::SafeBrowsingPtrInfo safe_browsing_info_;
+-  safe_browsing::mojom::SafeBrowsingPtr safe_browsing_;
+-
+   THREAD_CHECKER(thread_checker_);
+ 
+   DISALLOW_ASSIGN(WebSocketHandshakeThrottleProviderImpl);
+--- a/chrome/renderer/websocket_handshake_throttle_provider_impl.cc
++++ b/chrome/renderer/websocket_handshake_throttle_provider_impl.cc
+@@ -6,7 +6,6 @@
+ 
+ #include <utility>
+ 
+-#include "components/safe_browsing/renderer/websocket_sb_handshake_throttle.h"
+ #include "content/public/common/service_names.mojom.h"
+ #include "content/public/renderer/render_thread.h"
+ #include "services/service_manager/public/cpp/connector.h"
+@@ -15,9 +14,6 @@
+ WebSocketHandshakeThrottleProviderImpl::
+     WebSocketHandshakeThrottleProviderImpl() {
+   DETACH_FROM_THREAD(thread_checker_);
+-  content::RenderThread::Get()->GetConnector()->BindInterface(
+-      content::mojom::kBrowserServiceName,
+-      mojo::MakeRequest(&safe_browsing_info_));
+ }
+ 
+ WebSocketHandshakeThrottleProviderImpl::
+@@ -28,16 +24,12 @@ WebSocketHandshakeThrottleProviderImpl::
+ WebSocketHandshakeThrottleProviderImpl::WebSocketHandshakeThrottleProviderImpl(
+     const WebSocketHandshakeThrottleProviderImpl& other) {
+   DETACH_FROM_THREAD(thread_checker_);
+-  DCHECK(other.safe_browsing_);
+-  other.safe_browsing_->Clone(mojo::MakeRequest(&safe_browsing_info_));
+ }
+ 
+ std::unique_ptr<content::WebSocketHandshakeThrottleProvider>
+ WebSocketHandshakeThrottleProviderImpl::Clone(
+     scoped_refptr<base::SingleThreadTaskRunner> task_runner) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+-  if (safe_browsing_info_)
+-    safe_browsing_.Bind(std::move(safe_browsing_info_), std::move(task_runner));
+   return base::WrapUnique(new WebSocketHandshakeThrottleProviderImpl(*this));
+ }
+ 
+@@ -46,8 +38,5 @@ WebSocketHandshakeThrottleProviderImpl::
+     int render_frame_id,
+     scoped_refptr<base::SingleThreadTaskRunner> task_runner) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+-  if (safe_browsing_info_)
+-    safe_browsing_.Bind(std::move(safe_browsing_info_), std::move(task_runner));
+-  return std::make_unique<safe_browsing::WebSocketSBHandshakeThrottle>(
+-      safe_browsing_.get(), render_frame_id);
++  return 0;
+ }
+--- a/chrome/browser/win/conflicts/module_info_util.cc
++++ b/chrome/browser/win/conflicts/module_info_util.cc
+@@ -21,7 +21,6 @@
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/win/scoped_handle.h"
+ #include "base/win/wincrypt_shim.h"
+-#include "chrome/common/safe_browsing/pe_image_reader_win.h"
+ 
+ // This must be after wincrypt and wintrust.
+ #include <mscat.h>
+@@ -322,13 +321,6 @@ bool GetModuleImageSizeAndTimeDateStamp(
+   if (bytes_read == -1)
+     return false;
+ 
+-  safe_browsing::PeImageReader pe_image_reader;
+-  if (!pe_image_reader.Initialize(buffer.get(), bytes_read))
+-    return false;
+-
+-  *size_of_image = pe_image_reader.GetSizeOfImage();
+-  *time_date_stamp = pe_image_reader.GetCoffFileHeader()->TimeDateStamp;
+-
+   return true;
+ }
+ 
+--- a/chrome/common/webui_url_constants.cc
++++ b/chrome/common/webui_url_constants.cc
+@@ -7,7 +7,6 @@
+ #include "base/stl_util.h"
+ #include "base/strings/string_piece.h"
+ #include "components/nacl/common/buildflags.h"
+-#include "components/safe_browsing/web_ui/constants.h"
+ #include "extensions/buildflags/buildflags.h"
+ 
+ namespace chrome {
+@@ -513,7 +512,6 @@ const char* const kChromeHostURLs[] = {
+     kChromeUISignInInternalsHost,
+     kChromeUISiteEngagementHost,
+     kChromeUINTPTilesInternalsHost,
+-    safe_browsing::kChromeUISafeBrowsingHost,
+     kChromeUISuggestionsHost,
+     kChromeUISupervisedUserInternalsHost,
+     kChromeUISyncInternalsHost,
+--- a/chrome/browser/ui/blocked_content/popup_blocker.cc
++++ b/chrome/browser/ui/blocked_content/popup_blocker.cc
+@@ -9,12 +9,10 @@
+ #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/ui/blocked_content/popup_blocker_tab_helper.h"
+-#include "chrome/browser/ui/blocked_content/safe_browsing_triggered_popup_blocker.h"
+ #include "chrome/browser/ui/browser_navigator_params.h"
+ #include "chrome/common/chrome_switches.h"
+ #include "components/content_settings/core/browser/host_content_settings_map.h"
+ #include "components/content_settings/core/common/content_settings.h"
+-#include "components/safe_browsing/triggers/ad_popup_trigger.h"
+ #include "content/public/browser/page_navigator.h"
+ #include "content/public/browser/web_contents.h"
+ 
+@@ -58,13 +56,6 @@ PopupBlockType ShouldBlockPopup(content:
+           blink::WebTriggeringEventInfo::kFromUntrustedEvent) {
+     return PopupBlockType::kNotBlocked;
+   }
+-
+-  auto* safe_browsing_blocker =
+-      SafeBrowsingTriggeredPopupBlocker::FromWebContents(web_contents);
+-  if (safe_browsing_blocker &&
+-      safe_browsing_blocker->ShouldApplyAbusivePopupBlocker()) {
+-    return PopupBlockType::kAbusive;
+-  }
+   return PopupBlockType::kNotBlocked;
+ }
+ 
+@@ -92,12 +83,6 @@ bool MaybeBlockPopup(content::WebContent
+   auto* popup_blocker = PopupBlockerTabHelper::FromWebContents(web_contents);
+   if (popup_blocker && block_type != PopupBlockType::kNotBlocked) {
+     popup_blocker->AddBlockedPopup(params, window_features, block_type);
+-    if (safe_browsing::AdPopupTrigger::FromWebContents(web_contents)) {
+-      content::RenderFrameHost* source_frame =
+-          GetSourceFrameForPopup(params, open_url_params, web_contents);
+-      safe_browsing::AdPopupTrigger::FromWebContents(web_contents)
+-          ->PopupWasBlocked(source_frame);
+-    }
+     return true;
+   }
+   return false;
+--- a/chrome/browser/ui/blocked_content/popup_blocker_tab_helper.cc
++++ b/chrome/browser/ui/blocked_content/popup_blocker_tab_helper.cc
+@@ -14,7 +14,6 @@
+ #include "chrome/browser/ui/blocked_content/blocked_window_params.h"
+ #include "chrome/browser/ui/blocked_content/list_item_position.h"
+ #include "chrome/browser/ui/blocked_content/popup_tracker.h"
+-#include "chrome/browser/ui/blocked_content/safe_browsing_triggered_popup_blocker.h"
+ #include "chrome/browser/ui/browser_navigator.h"
+ #include "chrome/browser/ui/browser_navigator_params.h"
+ #include "chrome/common/chrome_render_frame.mojom.h"
+@@ -48,7 +47,6 @@ struct PopupBlockerTabHelper::BlockedReq
+ 
+ PopupBlockerTabHelper::PopupBlockerTabHelper(content::WebContents* web_contents)
+     : content::WebContentsObserver(web_contents) {
+-  SafeBrowsingTriggeredPopupBlocker::MaybeCreate(web_contents);
+ }
+ 
+ PopupBlockerTabHelper::~PopupBlockerTabHelper() {
+--- a/chrome/browser/ui/browser.cc
++++ b/chrome/browser/ui/browser.cc
+@@ -174,7 +174,6 @@
+ #include "components/keep_alive_registry/scoped_keep_alive.h"
+ #include "components/omnibox/browser/location_bar_model_impl.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/triggers/ad_redirect_trigger.h"
+ #include "components/search/search.h"
+ #include "components/security_state/content/content_utils.h"
+ #include "components/security_state/core/security_state.h"
+@@ -1316,10 +1315,6 @@ void Browser::OnDidBlockNavigation(conte
+       framebust_helper->AddBlockedUrl(blocked_url, base::BindOnce(on_click));
+     }
+   }
+-  if (auto* trigger =
+-          safe_browsing::AdRedirectTrigger::FromWebContents(web_contents)) {
+-    trigger->OnDidBlockNavigation(initiator_url);
+-  }
+ }
+ 
+ content::PictureInPictureResult Browser::EnterPictureInPicture(
+--- a/chrome/browser/ui/webui/downloads/downloads_ui.cc
++++ b/chrome/browser/ui/webui/downloads/downloads_ui.cc
+@@ -15,7 +15,6 @@
+ #include "base/values.h"
+ #include "chrome/browser/defaults.h"
+ #include "chrome/browser/profiles/profile.h"
+-#include "chrome/browser/safe_browsing/advanced_protection_status_manager.h"
+ #include "chrome/browser/ui/webui/downloads/downloads_dom_handler.h"
+ #include "chrome/browser/ui/webui/localized_string.h"
+ #include "chrome/browser/ui/webui/managed_ui_handler.h"
+@@ -51,10 +50,6 @@ content::WebUIDataSource* CreateDownload
+   content::WebUIDataSource* source =
+       content::WebUIDataSource::Create(chrome::kChromeUIDownloadsHost);
+ 
+-  bool requests_ap_verdicts = safe_browsing::AdvancedProtectionStatusManager::
+-      RequestsAdvancedProtectionVerdicts(profile);
+-  source->AddBoolean("requestsApVerdicts", requests_ap_verdicts);
+-
+   static constexpr LocalizedString kStrings[] = {
+       {"title", IDS_DOWNLOAD_TITLE},
+       {"searchResultsPlural", IDS_SEARCH_RESULTS_PLURAL},
+@@ -97,11 +92,8 @@ content::WebUIDataSource* CreateDownload
+ 
+   source->AddLocalizedString("dangerDownloadDesc",
+                              IDS_BLOCK_REASON_DANGEROUS_DOWNLOAD);
+-  source->AddLocalizedString(
+-      "dangerUncommonDesc",
+-      requests_ap_verdicts
+-          ? IDS_BLOCK_REASON_UNCOMMON_DOWNLOAD_IN_ADVANCED_PROTECTION
+-          : IDS_BLOCK_REASON_UNCOMMON_DOWNLOAD);
++  source->AddLocalizedString("dangerUncommonDesc",
++                             IDS_BLOCK_REASON_UNCOMMON_DOWNLOAD);
+   source->AddLocalizedString("dangerSettingsDesc",
+                              IDS_BLOCK_REASON_UNWANTED_DOWNLOAD);
+ 
+--- a/chrome/browser/ui/webui/management_ui.cc
++++ b/chrome/browser/ui/webui/management_ui.cc
+@@ -17,7 +17,6 @@
+ #include "chrome/grit/browser_resources.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "chrome/grit/theme_resources.h"
+-#include "components/safe_browsing/common/safebrowsing_constants.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "extensions/buildflags/buildflags.h"
+ #include "ui/base/l10n/l10n_util.h"
+@@ -91,10 +90,6 @@ content::WebUIDataSource* CreateManageme
+   AddLocalizedStringsBulk(source, kLocalizedStrings,
+                           base::size(kLocalizedStrings));
+ 
+-  source->AddString(kManagementExtensionReportSafeBrowsingWarnings,
+-                    l10n_util::GetStringFUTF16(
+-                        IDS_MANAGEMENT_EXTENSION_REPORT_SAFE_BROWSING_WARNINGS,
+-                        base::UTF8ToUTF16(safe_browsing::kSafeBrowsingUrl)));
+ #if defined(OS_CHROMEOS)
+   source->AddString("managementDeviceLearnMoreUrl",
+                     chrome::kLearnMoreEnterpriseURL);
+--- a/components/security_interstitials/content/security_interstitial_controller_client.h
++++ b/components/security_interstitials/content/security_interstitial_controller_client.h
+@@ -49,8 +49,6 @@ class SecurityInterstitialControllerClie
+   void LaunchDateAndTimeSettings() override;
+ 
+  protected:
+-  // security_interstitials::ControllerClient overrides.
+-  const std::string GetExtendedReportingPrefName() const override;
+   content::WebContents* web_contents_;
+ 
+  private:
+--- a/chrome/browser/ssl/ssl_error_controller_client.cc
++++ b/chrome/browser/ssl/ssl_error_controller_client.cc
+@@ -22,7 +22,6 @@
+ #include "chrome/common/chrome_features.h"
+ #include "chrome/common/pref_names.h"
+ #include "chrome/common/url_constants.h"
+-#include "components/safe_browsing/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/web_contents.h"
+ 
+--- a/components/security_interstitials/core/controller_client.h
++++ b/components/security_interstitials/core/controller_client.h
+@@ -109,9 +109,6 @@ class ControllerClient {
+ 
+   void SetBaseHelpCenterUrlForTesting(const GURL& test_url);
+ 
+- protected:
+-  virtual const std::string GetExtendedReportingPrefName() const = 0;
+-
+  private:
+   std::unique_ptr<MetricsHelper> metrics_helper_;
+   // Link to the help center.
+--- a/components/security_interstitials/core/controller_client.cc
++++ b/components/security_interstitials/core/controller_client.cc
+@@ -36,7 +36,6 @@ MetricsHelper* ControllerClient::metrics
+ 
+ void ControllerClient::SetReportingPreference(bool report) {
+   DCHECK(GetPrefService());
+-  GetPrefService()->SetBoolean(GetExtendedReportingPrefName(), report);
+   metrics_helper_->RecordUserInteraction(
+       report ? MetricsHelper::SET_EXTENDED_REPORTING_ENABLED
+              : MetricsHelper::SET_EXTENDED_REPORTING_DISABLED);
+--- a/components/password_manager/core/browser/password_store.cc
++++ b/components/password_manager/core/browser/password_store.cc
+@@ -37,7 +37,6 @@
+ #if defined(SYNC_PASSWORD_REUSE_DETECTION_ENABLED)
+ #include "base/strings/string16.h"
+ #include "components/password_manager/core/browser/password_store_signin_notifier.h"
+-#include "components/safe_browsing/common/safe_browsing_prefs.h"
+ #endif
+ 
+ using autofill::PasswordForm;
+@@ -476,10 +475,7 @@ void PasswordStore::SchedulePasswordHash
+ 
+ void PasswordStore::ScheduleEnterprisePasswordURLUpdate() {
+   std::vector<GURL> enterprise_login_urls;
+-  safe_browsing::GetPasswordProtectionLoginURLsPref(*prefs_,
+-                                                    &enterprise_login_urls);
+-  GURL enterprise_change_password_url =
+-      safe_browsing::GetPasswordProtectionChangePasswordURLPref(*prefs_);
++  GURL enterprise_change_password_url = GURL();
+ 
+   ScheduleTask(base::BindRepeating(&PasswordStore::SaveEnterprisePasswordURLs,
+                                    this, base::Passed(&enterprise_login_urls),

--- a/patches/ungoogled-chromium/windows/windows-fix-enum-conflict.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-enum-conflict.patch
@@ -2,7 +2,7 @@
 
 --- a/extensions/browser/api/feedback_private/feedback_private_api.cc
 +++ b/extensions/browser/api/feedback_private/feedback_private_api.cc
-@@ -390,7 +390,7 @@ void FeedbackPrivateSendFeedbackFunction
+@@ -389,7 +389,7 @@ void FeedbackPrivateSendFeedbackFunction
      bool success) {
    Respond(TwoArguments(
        std::make_unique<base::Value>(feedback_private::ToString(
@@ -13,7 +13,7 @@
    if (!success) {
 --- a/extensions/common/api/feedback_private.idl
 +++ b/extensions/common/api/feedback_private.idl
-@@ -100,7 +100,7 @@ namespace feedbackPrivate {
+@@ -96,7 +96,7 @@ namespace feedbackPrivate {
    };
  
    // Status of the sending of a feedback report.
@@ -21,4 +21,4 @@
 +  enum Status {success1, delayed};
  
    // The type of the landing page shown to the user when the feedback report is
-   // successfully sent.
+   // successfully sent, if one should be shown.

--- a/patches/ungoogled-chromium/windows/windows-fix-fingerprinting.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-fingerprinting.patch
@@ -1,0 +1,64 @@
+# Fixes linking errors associated with the fingerprinting switches added by ungoogled-chromium.
+
+--- a/content/public/common/content_switches.h
++++ b/content/public/common/content_switches.h
+@@ -287,6 +287,10 @@ CONTENT_EXPORT extern const char kPrefet
+ CONTENT_EXPORT extern const char kDeviceScaleFactor[];
+ CONTENT_EXPORT extern const char kDisableLegacyIntermediateWindow[];
+ CONTENT_EXPORT extern const char kEnableWin7WebRtcHWH264Decoding[];
++// Defines all the fingerprinting command-line switches (ungoogled-chromium).
++CONTENT_EXPORT extern const char kFingerprintingClientRectsNoise[];
++CONTENT_EXPORT extern const char kFingerprintingCanvasMeasureTextNoise[];
++CONTENT_EXPORT extern const char kFingerprintingCanvasImageDataNoise[];
+ // Switch to pass the font cache shared memory handle to the renderer.
+ CONTENT_EXPORT extern const char kFontCacheSharedHandle[];
+ CONTENT_EXPORT extern const char kPpapiAntialiasedTextEnabled[];
+--- a/content/public/common/content_switches.cc
++++ b/content/public/common/content_switches.cc
+@@ -1012,6 +1012,15 @@ const char kDisableLegacyIntermediateWin
+ const char kEnableWin7WebRtcHWH264Decoding[] =
+     "enable-win7-webrtc-hw-h264-decoding";
+ 
++// Enable fingerprinting deception for getClientRects and getBoundingClientRect
++const char kFingerprintingClientRectsNoise[] = "fingerprinting-client-rects-noise";
++
++// Enable fingerprinting deception for measureText
++const char kFingerprintingCanvasMeasureTextNoise[] = "fingerprinting-canvas-measuretext-noise";
++
++// Enable fingerprinting deception for Canvas image data
++const char kFingerprintingCanvasImageDataNoise[] = "fingerprinting-canvas-image-data-noise";
++
+ // DirectWrite FontCache is shared by browser to renderers using shared memory.
+ // This switch allows us to pass the shared memory handle to the renderer.
+ const char kFontCacheSharedHandle[] = "font-cache-shared-handle";
+--- a/third_party/ungoogled/ungoogled_switches.cc
++++ b/third_party/ungoogled/ungoogled_switches.cc
+@@ -6,6 +6,7 @@
+ 
+ namespace switches {
+ 
++#if !defined(OS_WIN)
+ // Enable fingerprinting deception for getClientRects and getBoundingClientRect
+ const char kFingerprintingClientRectsNoise[] = "fingerprinting-client-rects-noise";
+ 
+@@ -14,5 +15,6 @@ const char kFingerprintingCanvasMeasureT
+ 
+ // Enable fingerprinting deception for Canvas image data
+ const char kFingerprintingCanvasImageDataNoise[] = "fingerprinting-canvas-image-data-noise";
++#endif
+ 
+ }  // namespace switches
+--- a/third_party/ungoogled/ungoogled_switches.h
++++ b/third_party/ungoogled/ungoogled_switches.h
+@@ -9,9 +9,11 @@
+ 
+ namespace switches {
+ 
++#if !defined(OS_WIN)
+ extern const char kFingerprintingClientRectsNoise[];
+ extern const char kFingerprintingCanvasMeasureTextNoise[];
+ extern const char kFingerprintingCanvasImageDataNoise[];
++#endif
+ 
+ }
+ 


### PR DESCRIPTION
PRs #12 and #13 should be merged first.

This PR allows all users to finally get a working build of ungoogled-chromium on Windows while removing as much of Google's Safe Browsing as possible, thus solving issues #2 and #8.