### PR TITLE
Require Python 2 to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 1. Setup the following:
 
     * 7-zip
-    * Python 3.6+ with pypiwin32 module (`pip install pypiwin32`)
+    * Python 3.6+ (for build and packaging scripts used below)
 	    * At the end of the Python installer, click the button to lift the `MAX_PATH` length restriction.
+    * Python 2.7 (for scripts in the Chromium source tree), with pypiwin32 module (`pip install pypiwin32`)
 
-2. Make sure Python 3.6+ is set in the user or system environment variable `PATH` as `python`.
+2. Make sure Python 2.7 is set in the user or system environment variable `PATH` as `python`.
 
 ### Building
 
-NOTE: The commands below assume the `py` command was installed by Python 3 into `PATH`. If this is not the case, then substitute it with `python`.
+NOTE: The commands below assume the `py` command was installed by Python 3 into `PATH`. If this is not the case, then substitute it with `python3`.
 
 Run in `cmd.exe`:
 

--- a/build.py
+++ b/build.py
@@ -66,33 +66,30 @@ def _run_build_process(*args, **kwargs):
                    **kwargs)
 
 
-def _test_python(error_exit):
+def _test_python2(error_exit):
     """
-    Tests if Python 3 is setup with the proper requirements
+    Tests if Python 2 is setup with the proper requirements
     """
-    python3_exe = shutil.which('python')
-    if not python3_exe:
+    python2_exe = shutil.which('python')
+    if not python2_exe:
         error_exit('Could not find "python" in PATH')
 
-    # Check Python version is at least 3.6
-    result = subprocess.run((python3_exe, '--version'),
-                            stdout=subprocess.PIPE,
+    # Check Python version is at least 2.7.9 to avoid exec issues
+    result = subprocess.run((python2_exe, '--version'),
+                            stderr=subprocess.PIPE,
                             check=True,
                             universal_newlines=True)
-    match = re.fullmatch(r'Python 3\.([0-9])\.([0-9]+)', result.stdout.strip())
+    match = re.fullmatch(r'Python 2\.7\.([0-9]+)', result.stderr.strip())
     if not match:
-        error_exit('Could not detect Python 3 version from output: {}'.format(
+        error_exit('Could not detect Python 2 version from output: {}'.format(
             result.stdout.strip()))
-    if int(match.group(1)) < 6:
-        error_exit('At least Python 3.6 is required; found 3.{}.{}'.format(
-            match.group(1),
-            match.group(2),
-        ))
+    if int(match.group(1)) < 9:
+        error_exit('At least Python 2.7.9 is required; found 2.7.{}'.format(match.group(1)))
 
     # Check for pypiwin32 module
-    result = subprocess.run((python3_exe, '-c', 'import win32api'))
+    result = subprocess.run((python2_exe, '-c', 'import win32api'))
     if result.returncode:
-        error_exit('Unable to find pypiwin32 module.')
+        error_exit('Unable to find pypiwin32 module in Python 2 installation.')
 
 
 def _make_tmp_paths():
@@ -126,7 +123,7 @@ def main():
     domsubcache = _ROOT_DIR / 'build' / 'domsubcache.tar.gz'
 
     # Test environment
-    _test_python(parser.error)
+    _test_python2(parser.error)
 
     # Setup environment
     source_tree.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The Python scripts in the Chromium source tree have not been converted to Python 3 yet, so we cannot drop Python 2.