### PR TITLE
Add ability to compile mini-installer

### DIFF
--- a/build.py
+++ b/build.py
@@ -57,6 +57,7 @@ def _run_build_process(*args, **kwargs):
     """
     # Add call to set VC variables
     cmd_input = ['call "%s" >nul' % _get_vcvars_path()]
+    cmd_input.append('set DEPOT_TOOLS_WIN_TOOLCHAIN=0')
     cmd_input.append(' '.join(map('"{}"'.format, args)))
     cmd_input.append('exit\n')
     subprocess.run(('cmd.exe', '/k'),
@@ -191,9 +192,6 @@ def main():
 
     # Enter source tree to run build commands
     os.chdir(source_tree)
-
-    # Set "DEPOT_TOOLS_WIN_TOOLCHAIN" variable so gn gen doesn't return errors.
-    os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN'] = "0"
 
     # Run GN bootstrap
     _run_build_process(

--- a/build.py
+++ b/build.py
@@ -205,7 +205,7 @@ def main():
 
     # Run ninja
     _run_build_process('third_party\\ninja\\ninja.exe', '-C', 'out\\Default', 'chrome',
-                       'chromedriver')
+                       'chromedriver', 'mini_installer')
 
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -192,6 +192,9 @@ def main():
     # Enter source tree to run build commands
     os.chdir(source_tree)
 
+    # Set "DEPOT_TOOLS_WIN_TOOLCHAIN" variable so gn gen doesn't return errors.
+    os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN'] = "0"
+
     # Run GN bootstrap
     _run_build_process(
         shutil.which('python'), 'tools\\gn\\bootstrap\\bootstrap.py', '-o', 'out\\Default\\gn.exe',

--- a/package.py
+++ b/package.py
@@ -49,6 +49,7 @@ def main():
         'build/ungoogled-chromium_{}-{}.{}_installer.exe'.format(
             get_chromium_version(), _get_release_revision(), _get_packaging_revision()))
 
+    # We need to remove these files, or they'll end up in the zip files that will be generated.
     os.remove('build/src/out/Default/mini_installer.exe')
     os.remove('build/src/out/Default/mini_installer_exe_version.rc')
     os.remove('build/src/out/Default/setup.exe')

--- a/package.py
+++ b/package.py
@@ -13,8 +13,10 @@ if sys.version_info.major < 3:
     raise RuntimeError('Python 3 is required for this script.')
 
 import argparse
+import os
 import platform
 from pathlib import Path
+import shutil
 
 sys.path.insert(0, str(Path(__file__).resolve().parent / 'ungoogled-chromium' / 'utils'))
 import filescfg
@@ -42,6 +44,14 @@ def main():
               'This is the same as the "arch" key in FILES.cfg. '
               'Default (from platform.architecture()): %(default)s'))
     args = parser.parse_args()
+
+    shutil.copyfile('build/src/out/Default/mini_installer.exe',
+        'build/ungoogled-chromium_{}-{}.{}_installer.exe'.format(
+            get_chromium_version(), _get_release_revision(), _get_packaging_revision()))
+
+    os.remove('build/src/out/Default/mini_installer.exe')
+    os.remove('build/src/out/Default/mini_installer_exe_version.rc')
+    os.remove('build/src/out/Default/setup.exe')
 
     build_outputs = Path('build/src/out/Default')
     output = Path('build/ungoogled-chromium_{}-{}.{}_windows.zip'.format(

--- a/patches/series
+++ b/patches/series
@@ -12,3 +12,4 @@ ungoogled-chromium/windows/windows-fix-building-gn.patch
 ungoogled-chromium/windows/windows-disable-encryption.patch
 ungoogled-chromium/windows/windows-disable-machine-id.patch
 ungoogled-chromium/windows/windows-fix-fingerprinting.patch
+ungoogled-chromium/windows/windows-compile-mini-installer.patch

--- a/patches/ungoogled-chromium/windows/windows-compile-mini-installer.patch
+++ b/patches/ungoogled-chromium/windows/windows-compile-mini-installer.patch
@@ -1,0 +1,22 @@
+# To compile the mini-installer, a 7z archive of the browser has to be made.
+# Google's 7z executable gets purged, so we have to use the system's 7z executable.
+
+--- a/chrome/tools/build/win/create_installer_archive.py
++++ b/chrome/tools/build/win/create_installer_archive.py
+@@ -144,8 +144,14 @@ def GenerateDiffPatch(options, orig_file
+ 
+ def GetLZMAExec(build_dir):
+   if sys.platform == 'win32':
+-    lzma_exec = os.path.join(build_dir, "..", "..", "third_party",
+-                             "lzma_sdk", "Executable", "7za.exe")
++    # Taken from ungoogled-chromium's _extraction.py file, modified for Python 2
++    import _winreg
++    sub_key_7zfm = 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\7zFM.exe'
++
++    with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, sub_key_7zfm) as key_handle:
++      sevenzipfm_dir = _winreg.QueryValueEx(key_handle, 'Path')[0]
++
++    lzma_exec = os.path.join(sevenzipfm_dir, "7z.exe")
+   else:
+     lzma_exec = '7zr'  # Use system 7zr.
+   return lzma_exec


### PR DESCRIPTION
This PR allows users to compile the mini-installer, which is used to install ungoogled-chromium the same way a user would install any other program.

Unlike other installers, however, this mini-installer has a few key differences:

* There's no GUI whatsoever.
* The program is installed only for the user, so no admin privileges are required.

This PR also fixes an issue where if `DEPOT_TOOLS_WIN_TOOLCHAIN` is not set in the system variable, the build process fails with a "Toolchain is out of date" error. To address this, `build.py` will set that variable locally before GN bootstrap.