### PR TITLE
Update documentation: add tar to msys2

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A zip archive and an installer will be created under `build`.
 2. Run the following in a "MSYS2 MSYS" shell:
 
 ```sh
-pacman -S quilt python3 vim
+pacman -S quilt python3 vim tar
 # By default, there doesn't seem to be a vi command for less, quilt edit, etc.
 ln -s /usr/bin/vim /usr/bin/vi
 ```


### PR DESCRIPTION
I was having issues following the documentation: the download was stuck in msys2.
I figured it was because it was using the windows "tar" binary instead of the linux one.

Installing with pacman in MSYS2 fixed it, and probably is more bulletproof than the windows one.