### PR TITLE
Add chrome://flags entries for disable encryption & machine-id

### DIFF
--- a/patches/ungoogled-chromium/windows/windows-disable-encryption.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-encryption.patch
@@ -2,6 +2,17 @@
 # WARNING! Use ONLY if your hard drive is encrypted or if you know what you are doing.
 # See https://github.com/Eloston/ungoogled-chromium/issues/444
 
+--- a/chrome/browser/ungoogled_platform_flag_entries.h
++++ b/chrome/browser/ungoogled_platform_flag_entries.h
+@@ -4,4 +4,8 @@
+
+ #ifndef CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_ENTRIES_H_
+ #define CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_ENTRIES_H_
++    {"disable-encryption",
++     "Disable encryption",
++     "Disable encryption of cookies, passwords, and settings which uses a generated machine-specific encryption key.  This is used to enable portable user data directories.  ungoogled-chromium flag.",
++     kOsWin, SINGLE_VALUE_TYPE("disable-encryption")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_ENTRIES_H_
 --- a/components/os_crypt/os_crypt_win.cc
 +++ b/components/os_crypt/os_crypt_win.cc
 @@ -5,6 +5,7 @@

--- a/patches/ungoogled-chromium/windows/windows-disable-machine-id.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-machine-id.patch
@@ -1,6 +1,17 @@
 # Disable machine ID generation on Windows.
 # See https://github.com/Eloston/ungoogled-chromium/issues/444
 
+--- a/chrome/browser/ungoogled_platform_flag_entries.h
++++ b/chrome/browser/ungoogled_platform_flag_entries.h
+@@ -8,4 +8,8 @@
+      "Disable encryption",
+      "Disable encryption of cookies, passwords, and settings which uses a generated machine-specific encryption key.  This is used to enable portable user data directories.  ungoogled-chromium flag.",
+      kOsWin, SINGLE_VALUE_TYPE("disable-encryption")},
++    {"disable-machine-id",
++     "Disable machine ID",
++     "Disables use of a generated machine-specific ID to lock the user data directory to that machine.  This is used to enable portable user data directories.  ungoogled-chromium flag.",
++     kOsWin, SINGLE_VALUE_TYPE("disable-machine-id")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_ENTRIES_H_
 --- a/components/metrics/machine_id_provider_win.cc
 +++ b/components/metrics/machine_id_provider_win.cc
 @@ -9,6 +9,7 @@


### PR DESCRIPTION
This PR adds entries to `chrome://flags` for `windows-disable-encryption.patch` and `windows-disable-machine-id.patch` using a new set of headers created by https://github.com/Eloston/ungoogled-chromium/pull/1250.  

This is preemptive and shouldn't be merged until that PR has been included!  