### PR TITLE
Include VS prerelease in vcvars*.bat search

### DIFF
--- a/build.py
+++ b/build.py
@@ -40,7 +40,7 @@ def _get_vcvars_path(name='64'):
     """
     vswhere_exe = '%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe'
     result = subprocess.run(
-        '"{}" -latest -property installationPath'.format(vswhere_exe),
+        '"{}" -prerelease -latest -property installationPath'.format(vswhere_exe),
         shell=True,
         check=True,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
When searching for the Visual Studio installation path the build will fail if the installed version of VS2019 isn't considered a release version. It shouldn't stop the build process, and I'm not sure this is the best approach to solve this problem, but on VS2019 Community v16.9.4 this is the only way I could find to get past this step in the build process without hardcoding the path or receiving it as an argument.