### PR TITLE
fx windows-disable-rlz.patch for 90.0.4430.85

### DIFF
--- a/patches/ungoogled-chromium/windows/windows-disable-rlz.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-rlz.patch
@@ -31,9 +31,9 @@
 -  rlz_lib::ClearProductState(rlz_lib::CHROME, points);
 -
 -  // If chrome has been reactivated, clear all events for this brand as well.
--  base::string16 reactivation_brand_wide;
+-  std::wstring reactivation_brand_wide;
 -  if (GoogleUpdateSettings::GetReactivationBrand(&reactivation_brand_wide)) {
--    std::string reactivation_brand(base::UTF16ToASCII(reactivation_brand_wide));
+-    std::string reactivation_brand(base::WideToASCII(reactivation_brand_wide));
 -    rlz_lib::SupplementaryBranding branding(reactivation_brand.c_str());
 -    rlz_lib::ClearProductState(rlz_lib::CHROME, points);
 -  }


### PR DESCRIPTION
The previous version broke because of this commit: https://github.com/chromium/chromium/commit/11bd83875c0fff1da593f6df68b6a71c5d350cc9

This PR only has the minimal changes needed to fix it, so I didn't update the rest of the patch or line numbers.