### PR TITLE
Track main branch for official Chromium build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Windows packaging for [ungoogled-chromium](//github.com/Eloston/ungoogled-chromi
 
 ## Building
 
-Google only supports [Windows 7 x64 or newer](https://chromium.googlesource.com/chromium/src/+/refs/tags/89.0.4389.82/docs/windows_build_instructions.md#system-requirements). These instructions are tested on Windows 7 Professional x64.
+Google only supports [Windows 10 x64 or newer](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/windows_build_instructions.md#system-requirements). These instructions are tested on Windows 10 Pro x64.
 
 NOTE: The default configuration will build 64-bit binaries for maximum security (TODO: Link some explanation). This can be changed to 32-bit by setting `target_cpu` to `"x86"` in `flags.windows.gn`.
 
@@ -20,7 +20,7 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 
 #### Setting up Visual Studio
 
-[Follow the "Visual Studio" section of the official Windows build instructions](https://chromium.googlesource.com/chromium/src/+/refs/tags/89.0.4389.82/docs/windows_build_instructions.md#visual-studio).
+[Follow the "Visual Studio" section of the official Windows build instructions](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/windows_build_instructions.md#visual-studio).
 
 * Make sure to read through the entire section and install/configure all the required components.
 * If your Visual Studio is installed in a directory other than the default, you'll need to set a few environment variables to point the toolchains to your installation path. (Copied from [instructions for Electron](https://electronjs.org/docs/development/build-instructions-windows))


### PR DESCRIPTION
**tl;dr:** Updating the link to Chromium's official build instructions per major update is a nuisance, so just track their main branch instead. Google requires Windows 10 now, so update our instructions to reflect that.

**Long version:** Whenever there's a new major update for Chromium, we have to update the link to the official build instructions in the README. Usually, the build instructions don't change per update, but because of this, having to update the link is a nuisance. Plus, we might forget to update the link (the last time it was updated was when version 89 came out in March).

So instead of doing that, we'll just have the link point to the official instructions on the main branch. It's either that or update the link every four weeks.

In addition to that, Google now requires using Windows 10 or newer to build, so this PR will also update the instructions in the README to reflect such a change.