### PR TITLE
readme: Be more precise about required Windows 10 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 
 #### Other build requirements
 
-**IMPORTANT**: Currently, the `MAX_PATH` path length restriction (which is 260 characters by default) must be lifted in for our Python build scripts. This can be lifted in Windows 10 (Anniversary or newer) with the official installer for Python 3.6 or newer (you will see a button at the end of installation to do this). See [Issue #345](https://github.com/Eloston/ungoogled-chromium/issues/345) for other methods for other Windows versions.
+**IMPORTANT**: Currently, the `MAX_PATH` path length restriction (which is 260 characters by default) must be lifted in for our Python build scripts. This can be lifted in Windows 10 (v1607 or newer) with the official installer for Python 3.6 or newer (you will see a button at the end of installation to do this). See [Issue #345](https://github.com/Eloston/ungoogled-chromium/issues/345) for other methods for other Windows versions.
 
 1. Setup the following:
 


### PR DESCRIPTION
Use specific Windows 10 version numbers regarding the MAX_PATH requirements instead of generic names (since no-one remembers what version "Anniversary" actually stood for anymore).

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>