### PR TITLE
Update to ungoogled-chromium 110.0.5481.78-1

### DIFF
--- a/patches/ungoogled-chromium/windows/windows-compile-mini-installer.patch
+++ b/patches/ungoogled-chromium/windows/windows-compile-mini-installer.patch
@@ -3,7 +3,7 @@
 
 --- a/chrome/installer/mini_installer/BUILD.gn
 +++ b/chrome/installer/mini_installer/BUILD.gn
-@@ -166,7 +166,6 @@ action("mini_installer_archive") {
+@@ -169,7 +169,6 @@ action("mini_installer_archive") {
      "//chrome",
      "//chrome:chrome_dll",
      "//chrome/browser/extensions/default_extensions",

--- a/patches/ungoogled-chromium/windows/windows-disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1359,7 +1359,7 @@ config("compiler_deterministic") {
+@@ -1374,7 +1374,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {
@@ -15,8 +15,8 @@
  }
  
  declare_args() {
--  clang_version = "16.0.0"
-+  clang_version = "15.0.3"
+-  clang_version = "16"
++  clang_version = "15"
  }
  
  # Extension for shared library files (including leading dot).

--- a/patches/ungoogled-chromium/windows/windows-disable-download-warning-prompt.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-download-warning-prompt.patch
@@ -1,6 +1,6 @@
 --- a/components/download/internal/common/download_item_impl.cc
 +++ b/components/download/internal/common/download_item_impl.cc
-@@ -2452,7 +2452,7 @@ void DownloadItemImpl::SetDangerType(Dow
+@@ -2451,7 +2451,7 @@ void DownloadItemImpl::SetDangerType(Dow
                           TRACE_EVENT_SCOPE_THREAD, "danger_type",
                           GetDownloadDangerNames(danger_type).c_str());
    }

--- a/patches/ungoogled-chromium/windows/windows-disable-event-log.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-event-log.patch
@@ -3,7 +3,7 @@
 
 --- a/chrome/common/BUILD.gn
 +++ b/chrome/common/BUILD.gn
-@@ -417,7 +417,6 @@ static_library("common_lib") {
+@@ -419,7 +419,6 @@ static_library("common_lib") {
      ]
      deps += [
        "//chrome/chrome_elf:chrome_elf_main_include",

--- a/patches/ungoogled-chromium/windows/windows-disable-nodebug_assertion.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-nodebug_assertion.patch
@@ -1,9 +1,9 @@
 # Windows does not support weak symbols
 --- a/base/BUILD.gn
 +++ b/base/BUILD.gn
-@@ -1562,7 +1562,7 @@ mixed_component("base") {
-     "//third_party/abseil-cpp:absl",
-   ]
+@@ -1543,7 +1543,7 @@ component("base") {
+     public_deps += [ "//build/rust:cxx_cppdeps" ]
+   }
  
 -  if (use_custom_libcxx && enable_safe_libcxx && !is_debug) {
 +  if (!is_win && use_custom_libcxx && enable_safe_libcxx && !is_debug) {

--- a/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
@@ -17,7 +17,7 @@
        "//build:branding_buildflags",
 --- a/chrome/browser/chrome_browser_main_win.cc
 +++ b/chrome/browser/chrome_browser_main_win.cc
-@@ -393,15 +393,6 @@ void ShowCloseBrowserFirstMessageBox() {
+@@ -394,15 +394,6 @@ void ShowCloseBrowserFirstMessageBox() {
        l10n_util::GetStringUTF16(IDS_UNINSTALL_CLOSE_APP));
  }
  
@@ -33,7 +33,7 @@
  // Updates all Progressive Web App launchers in |profile_dir| to the latest
  // version.
  void UpdatePwaLaunchersForProfile(const base::FilePath& profile_dir) {
-@@ -613,23 +604,6 @@ void ChromeBrowserMainPartsWin::PostBrow
+@@ -624,23 +615,6 @@ void ChromeBrowserMainPartsWin::PostBrow
  
    InitializeChromeElf();
  
@@ -59,7 +59,7 @@
    content::GetUIThreadTaskRunner({})->PostDelayedTask(
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
-@@ -1244,8 +1244,6 @@ void RegisterLocalState(PrefRegistrySimp
+@@ -1277,8 +1277,6 @@ void RegisterLocalState(PrefRegistrySimp
                                  true);
    registry->RegisterBooleanPref(
        policy::policy_prefs::kNativeWindowOcclusionEnabled, true);
@@ -68,7 +68,7 @@
    MediaFoundationServiceMonitor::RegisterPrefs(registry);
    os_crypt::RegisterLocalStatePrefs(registry);
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
-@@ -1571,12 +1569,8 @@ void RegisterProfilePrefs(user_prefs::Pr
+@@ -1612,12 +1610,8 @@ void RegisterProfilePrefs(user_prefs::Pr
  
  #if BUILDFLAG(IS_WIN)
    CdmPrefServiceHelper::RegisterProfilePrefs(registry);

--- a/patches/ungoogled-chromium/windows/windows-fix-licenses-gn-path.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-licenses-gn-path.patch
@@ -1,5 +1,5 @@
---- a/tools/licenses.py
-+++ b/tools/licenses.py
+--- a/tools/licenses/licenses.py
++++ b/tools/licenses/licenses.py
 @@ -622,7 +622,7 @@ def _GnBinary():
    elif sys.platform == 'darwin':
      subdir = 'mac'


### PR DESCRIPTION
Builds and runs fine, just minor patch updates required:
- Only major clang version needs to be patched now in `windows-disable-clang-version-check.patch`
- Adapt path change in `windows-fix-licenses-gn-path.patch`

![image](https://user-images.githubusercontent.com/32164856/217769796-f598c5d9-a6b6-4536-824d-d6b381b67341.png)