### PR TITLE
Retry artifact upload on exceptions

### DIFF
--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -46,14 +46,32 @@ async function run() {
             await io.mv(x, newPath);
             return newPath;
         }));
-        await artifactClient.uploadArtifact(x86 ? 'chromium-x86' : 'chromium', packageList,
-            'C:\\ungoogled-chromium-windows\\build', {retentionDays: 1});
+        for (let i = 0; i < 5; ++i) {
+            try {
+                await artifactClient.uploadArtifact(x86 ? 'chromium-x86' : 'chromium', packageList,
+                    'C:\\ungoogled-chromium-windows\\build', {retentionDays: 3});
+                break;
+            } catch (e) {
+                console.error(`Upload artifact failed: ${e}`);
+                // Wait 10 seconds between the attempts
+                await new Promise(r => setTimeout(r, 10000));
+            }
+        }
     } else {
         await new Promise(r => setTimeout(r, 5000));
         await exec.exec('7z', ['a', '-tzip', 'C:\\ungoogled-chromium-windows\\artifacts.zip',
             'C:\\ungoogled-chromium-windows\\build\\src', '-mx=3', '-mtc=on'], {ignoreReturnCode: true});
-        await artifactClient.uploadArtifact(artifactName, ['C:\\ungoogled-chromium-windows\\artifacts.zip'],
-            'C:\\ungoogled-chromium-windows', {retentionDays: 1});
+        for (let i = 0; i < 5; ++i) {
+            try {
+                await artifactClient.uploadArtifact(artifactName, ['C:\\ungoogled-chromium-windows\\artifacts.zip'],
+                    'C:\\ungoogled-chromium-windows', {retentionDays: 3});
+                break;
+            } catch (e) {
+                console.error(`Upload artifact failed: ${e}`);
+                // Wait 10 seconds between the attempts
+                await new Promise(r => setTimeout(r, 10000));
+            }
+        }
         core.setOutput('finished', false);
     }
 }


### PR DESCRIPTION
The recent CI [build](https://github.com/ungoogled-software/ungoogled-chromium-windows/actions/runs/4630505652/jobs/8212342287) failed again due to an artifact upload error. The root cause is unknown. 

This PR adds a retry mechanism for artifact upload. 
It also sets the artifact retention period to 3 days just in case overwriting old artifacts doesn't refresh retention and causes a race condition. 