### PR TITLE
Update to ungoogled-chromium 114.0.5735.91-1

### DIFF
--- a/build.py
+++ b/build.py
@@ -180,12 +180,6 @@ def main():
             parser.exit(1)
 
         # Apply patches
-        # Apply temporary patches
-        patches.apply_patches(
-            patches.generate_patches_from_series(_ROOT_DIR / 'patches' / 'temp-patches', resolve=True),
-            _ROOT_DIR,
-            patch_bin_path=(source_tree / _PATCH_BIN_RELPATH)
-        )
         # First, ungoogled-chromium-patches
         patches.apply_patches(
             patches.generate_patches_from_series(_ROOT_DIR / 'ungoogled-chromium' / 'patches', resolve=True),

--- a/patches/series
+++ b/patches/series
@@ -21,3 +21,5 @@ ungoogled-chromium/windows/windows-fix-generate-resource-allowed-list.patch
 ungoogled-chromium/windows/windows-disable-clang-version-check.patch
 ungoogled-chromium/windows/windows-disable-nodebug_assertion.patch
 ungoogled-chromium/windows/windows-fix-licenses-gn-path.patch
+ungoogled-chromium/windows/windows-fix-missing-clang-features.patch
+ungoogled-chromium/windows/windows-fix-referrer-customization.patch

--- a/patches/temp-patches/remove-referrer-customization.patch
+++ b/patches/temp-patches/remove-referrer-customization.patch
@@ -1,7 +1,0 @@
---- a/ungoogled-chromium/patches/series
-+++ b/ungoogled-chromium/patches/series
-@@ -98,4 +98,3 @@ extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
- extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
- extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
- extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
--extra/ungoogled-chromium/add-flags-for-referrer-customization.patch

--- a/patches/temp-patches/series
+++ b/patches/temp-patches/series
@@ -1,1 +1,0 @@
-remove-referrer-customization.patch

--- a/patches/ungoogled-chromium/windows/windows-disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1398,7 +1398,7 @@ config("compiler_deterministic") {
+@@ -1407,7 +1407,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/windows/windows-disable-event-log.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-event-log.patch
@@ -3,7 +3,7 @@
 
 --- a/chrome/common/BUILD.gn
 +++ b/chrome/common/BUILD.gn
-@@ -424,7 +424,6 @@ static_library("common_lib") {
+@@ -430,7 +430,6 @@ static_library("common_lib") {
      ]
      deps += [
        "//chrome/chrome_elf:chrome_elf_main_include",

--- a/patches/ungoogled-chromium/windows/windows-disable-nodebug_assertion.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-nodebug_assertion.patch
@@ -1,7 +1,7 @@
 # Windows does not support weak symbols
 --- a/base/BUILD.gn
 +++ b/base/BUILD.gn
-@@ -1098,7 +1098,7 @@ component("base") {
+@@ -1093,7 +1093,7 @@ component("base") {
      public_deps += [ "//build/rust:cxx_cppdeps" ]
    }
  

--- a/patches/ungoogled-chromium/windows/windows-disable-reorder-fix-linking.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-reorder-fix-linking.patch
@@ -72,7 +72,7 @@
  python_library("chromedriver_replay_unittests") {
 --- a/tools/perf/chrome_telemetry_build/BUILD.gn
 +++ b/tools/perf/chrome_telemetry_build/BUILD.gn
-@@ -41,10 +41,6 @@ group("telemetry_chrome_test") {
+@@ -43,10 +43,6 @@ group("telemetry_chrome_test") {
      data_deps += [ "//chrome" ]
    }
  

--- a/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
@@ -59,7 +59,7 @@
    if (base::FeatureList::IsEnabled(features::kAppBoundEncryptionMetrics) &&
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
-@@ -1334,8 +1334,6 @@ void RegisterLocalState(PrefRegistrySimp
+@@ -1338,8 +1338,6 @@ void RegisterLocalState(PrefRegistrySimp
                                  true);
    registry->RegisterBooleanPref(
        policy::policy_prefs::kNativeWindowOcclusionEnabled, true);
@@ -68,7 +68,7 @@
    MediaFoundationServiceMonitor::RegisterPrefs(registry);
    os_crypt::RegisterLocalStatePrefs(registry);
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
-@@ -1671,12 +1669,8 @@ void RegisterProfilePrefs(user_prefs::Pr
+@@ -1675,12 +1673,8 @@ void RegisterProfilePrefs(user_prefs::Pr
  
  #if BUILDFLAG(IS_WIN)
    CdmPrefServiceHelper::RegisterProfilePrefs(registry);
@@ -134,7 +134,7 @@
 +#endif
 --- a/chrome/browser/signin/signin_util_win.cc
 +++ b/chrome/browser/signin/signin_util_win.cc
-@@ -268,12 +268,6 @@ bool IsGCPWUsedInOtherProfile(Profile* p
+@@ -273,12 +273,6 @@ bool IsGCPWUsedInOtherProfile(Profile* p
  }
  
  void SigninWithCredentialProviderIfPossible(Profile* profile) {

--- a/patches/ungoogled-chromium/windows/windows-fix-command-ids.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-command-ids.patch
@@ -19,7 +19,7 @@
  #define IDC_MOVE_TAB_TO_NEW_WINDOW          34054
  
 @@ -84,16 +78,6 @@
- #define IDC_SITE_SETTINGS               34062
+ #define IDC_WEB_APP_SETTINGS            34062
  #define IDC_WEB_APP_MENU_APP_INFO    34063
  
 -#if BUILDFLAG(IS_CHROMEOS_ASH)
@@ -35,7 +35,7 @@
  // Page-related commands
  #define IDC_BOOKMARK_THIS_TAB           35000
  #define IDC_BOOKMARK_ALL_TABS           35001
-@@ -227,7 +211,7 @@
+@@ -234,7 +218,7 @@
  #define IDC_CHROME_TIPS                40263
  #define IDC_CHROME_WHATS_NEW           40264
  
@@ -44,7 +44,7 @@
  #define IDC_LACROS_DATA_MIGRATION      40265
  #endif
  
-@@ -422,7 +406,7 @@
+@@ -434,7 +418,7 @@
  #define IDC_MEDIA_ROUTER_TOGGLE_MEDIA_REMOTING 51208
  
  // Context menu items for media toolbar button
@@ -53,7 +53,7 @@
  #define IDC_MEDIA_TOOLBAR_CONTEXT_REPORT_CAST_ISSUE 51209
  #endif
  #define IDC_MEDIA_TOOLBAR_CONTEXT_SHOW_OTHER_SESSIONS 51210
-@@ -456,13 +440,13 @@
+@@ -468,13 +452,13 @@
  #define IDC_CONTENT_CONTEXT_ACCESSIBILITY_LABELS 52411
  #define IDC_CONTENT_CONTEXT_ACCESSIBILITY_LABELS_TOGGLE_ONCE 52412
  

--- a/patches/ungoogled-chromium/windows/windows-fix-missing-clang-features.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-missing-clang-features.patch
@@ -1,0 +1,19 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -685,7 +685,6 @@ config("compiler") {
+         "/lldltocache:" +
+             rebase_path("$root_out_dir/thinlto-cache", root_build_dir),
+         "/lldltocachepolicy:$cache_policy",
+-        "-mllvm:-disable-auto-upgrade-debug-info",
+       ]
+     } else {
+       ldflags += [ "-flto=thin" ]
+@@ -732,7 +731,7 @@ config("compiler") {
+         # toolchain has this flag.
+         # We only use one version of LLVM within a build so there's no need to
+         # upgrade debug info, which can be expensive since it runs the verifier.
+-        ldflags += [ "-Wl,-mllvm,-disable-auto-upgrade-debug-info" ]
++        ldflags += [ "-Wl,-mllvm" ]
+       }
+     }
+ 

--- a/patches/ungoogled-chromium/windows/windows-fix-referrer-customization.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-referrer-customization.patch
@@ -1,0 +1,22 @@
+--- a/chrome/test/chromedriver/BUILD.gn
++++ b/chrome/test/chromedriver/BUILD.gn
+@@ -312,8 +312,7 @@ source_set("lib") {
+     "//base/third_party/dynamic_annotations",
+     "//build:branding_buildflags",
+     "//build:chromeos_buildflags",
+-    "//chrome/common:constants",
+-    "//chrome/common:version_header",
++    "//chrome/common",
+     "//chrome/test/chromedriver/constants:version_header",
+     "//components/crx_file",
+     "//components/embedder_support",
+--- a/tools/v8_context_snapshot/BUILD.gn
++++ b/tools/v8_context_snapshot/BUILD.gn
+@@ -82,6 +82,7 @@ if (use_v8_context_snapshot) {
+       sources = [ "v8_context_snapshot_generator.cc" ]
+ 
+       deps = [
++        "//chrome/common",
+         "//gin:gin",
+         "//mojo/core/embedder",
+         "//services/service_manager/public/cpp",

--- a/patches/ungoogled-chromium/windows/windows-fix-showIncludes.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-showIncludes.patch
@@ -1,6 +1,6 @@
 --- a/build/toolchain/win/toolchain.gni
 +++ b/build/toolchain/win/toolchain.gni
-@@ -57,6 +57,9 @@ template("single_msvc_toolchain") {
+@@ -58,6 +58,9 @@ template("single_msvc_toolchain") {
        toolchain_is_clang = is_clang
      }
  
@@ -10,7 +10,7 @@
      # When the invoker has explicitly overridden use_goma or cc_wrapper in the
      # toolchain args, use those values, otherwise default to the global one.
      # This works because the only reasonable override that toolchains might
-@@ -191,15 +194,11 @@ template("single_msvc_toolchain") {
+@@ -192,15 +195,11 @@ template("single_msvc_toolchain") {
  
      # Disabled with cc_wrapper because of
      # https://github.com/mozilla/sccache/issues/1013

--- a/patches/ungoogled-chromium/windows/windows-no-unknown-warnings.patch
+++ b/patches/ungoogled-chromium/windows/windows-no-unknown-warnings.patch
@@ -3,7 +3,7 @@
 
 --- a/build/config/win/BUILD.gn
 +++ b/build/config/win/BUILD.gn
-@@ -71,6 +71,7 @@ config("compiler") {
+@@ -69,6 +69,7 @@ config("compiler") {
    if (is_clang) {
      cflags += [
        "/Zc:twoPhase",


### PR DESCRIPTION
Builds and runs fine:

![image](https://github.com/ungoogled-software/ungoogled-chromium-windows/assets/32164856/f84c82da-d514-4c2c-bf65-dc31a5bbf9df)

Notable changes:
- The previous q&d fix for the referrer customization patch has been removed and fixed by the new `windows-fix-referrer-customization.patch` patch
- The `windows-fix-missing-clang-features.patch` patch has been added to remove the `-disable-auto-upgrade-debug-info` llvm flag which is not present in clang-15.