### PR TITLE
Update to ungoogled-chromium 116.0.5845.180-1

### DIFF
--- a/flags.windows.gn
+++ b/flags.windows.gn
@@ -13,3 +13,4 @@ blink_symbol_level=0
 v8_symbol_level=0
 symbol_level=0
 enable_rust=false
+enable_mse_mpeg2ts_stream_parser=true


### PR DESCRIPTION
Builds and runs fine, no patch updates required. I added the `enable_mse_mpeg2ts_stream_parser=true` flag which was removed in the core repo by https://github.com/ungoogled-software/ungoogled-chromium/pull/2471

![image](https://github.com/ungoogled-software/ungoogled-chromium-windows/assets/32164856/9df63a34-470d-4ed1-be73-93270babadb5)
