### PR TITLE
Update to ungoogled-chromium 119.0.6045.199-1

### DIFF
--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -11749,9 +11749,6 @@ third_party/openscreen/src/test/test_main.cc
 third_party/openscreen/src/testing/libfuzzer/BUILD.gn
 third_party/openscreen/src/third_party/abseil/BUILD.gn
 third_party/openscreen/src/third_party/boringssl/BUILD.gn
-third_party/openscreen/src/third_party/mozilla/LICENSE.txt
-third_party/openscreen/src/third_party/mozilla/url_parse.cc
-third_party/openscreen/src/third_party/mozilla/url_parse.h
 third_party/openscreen/src/third_party/protobuf/CHANGES.txt
 third_party/openscreen/src/third_party/protobuf/src/google/protobuf/any.cc
 third_party/openscreen/src/third_party/protobuf/src/google/protobuf/any.h


### PR DESCRIPTION
Builds and runs fine, no patch updates required:

![image](https://github.com/ungoogled-software/ungoogled-chromium-windows/assets/32164856/8fd9cc4d-e889-43d4-bba6-8a67d88c873e)