### PR TITLE
Update to ungoogled-chromium 125.0.6422.76-1

### DIFF
--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -2699,7 +2699,6 @@ components/enterprise/data_controls/data_controls_policy_handler_unittest.cc
 components/enterprise/data_controls/rule_unittest.cc
 components/error_page/common/localized_error.cc
 components/error_page_strings.grdp
-components/exo/buffer.h
 components/exo/data_offer_unittest.cc
 components/exo/drag_drop_operation_unittest.cc
 components/exo/seat_unittest.cc

--- a/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
@@ -15,18 +15,6 @@
  
      deps += [
        "//build:branding_buildflags",
---- a/chrome/browser/net/profile_network_context_service.cc
-+++ b/chrome/browser/net/profile_network_context_service.cc
-@@ -952,8 +952,7 @@ ProfileNetworkContextService::CreateClie
- 
-   return store;
- #elif BUILDFLAG(IS_WIN)
--  return GetWrappedCertStore(profile_,
--                             std::make_unique<net::ClientCertStoreWin>());
-+  return nullptr;
- #elif BUILDFLAG(IS_MAC)
-   return GetWrappedCertStore(profile_,
-                              std::make_unique<net::ClientCertStoreMac>());
 --- a/chrome/browser/safe_browsing/BUILD.gn
 +++ b/chrome/browser/safe_browsing/BUILD.gn
 @@ -7,6 +7,7 @@ import("//components/safe_browsing/build


### PR DESCRIPTION
Builds and runs fine, no* patch updates required:

![image](https://github.com/ungoogled-software/ungoogled-chromium-windows/assets/32164856/d74788c4-3079-49a4-8790-e54ccb704504)

*) The safebrowsing patch update from .60 has been integrated into the core repo and has therefore been removed from our repo.