### PR TITLE
Update to ungoogled-chromium 128.0.6613.119-1

### DIFF
--- a/patches/ungoogled-chromium/windows/windows-fix-building-gn.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-gn.patch
@@ -35,3 +35,13 @@
    description = CXX $out
    deps = msvc
  
+--- a/tools/gn/build/gen.py
++++ b/tools/gn/build/gen.py
+@@ -575,6 +575,7 @@ def WriteGNNinja(path, platform, host, o
+         '/D_SCL_SECURE_NO_DEPRECATE',
+         '/D_UNICODE',
+         '/D_WIN32_WINNT=0x0A00',
++        '/D_LEGACY_CODE_ASSUMES_STRING_VIEW_INCLUDES_XSTRING',
+         '/FS',
+         '/W4',
+         '/Zi',


### PR DESCRIPTION
Builds and runs fine. Includes @Nifury's patch (https://github.com/Nifury/ungoogled-chromium-windows/commit/d0913316ffd7f31b87d5400a14a5d85473ed2301) to fix the  CI.

![image](https://github.com/user-attachments/assets/f84a5682-2e7e-463a-a040-3a0491a24b08)
