### PR TITLE
Enhancements to package.py

### DIFF
--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -42,14 +42,6 @@ async function run() {
         const globber = await glob.create('C:\\ungoogled-chromium-windows\\build\\ungoogled-chromium*',
             {matchDirectories: false});
         let packageList = await globber.glob();
-        packageList = await Promise.all(packageList.map(async x => {
-            const part1 = x.substring(0, x.length - 4);
-            const part2 = x86 ? '_x86' : '_x64';
-            const part3 = x.substring(x.length - 4, x.length);
-            const newPath = part1 + part2 + part3;
-            await io.mv(x, newPath);
-            return newPath;
-        }));
         for (let i = 0; i < 5; ++i) {
             try {
                 await artifactClient.uploadArtifact(x86 ? 'chromium-x86' : 'chromium', packageList,

--- a/build.py
+++ b/build.py
@@ -163,16 +163,16 @@ def main():
             # Download chromium tarball
             get_logger().info('Downloading chromium tarball...')
             download_info = downloads.DownloadInfo([_ROOT_DIR / 'ungoogled-chromium' / 'downloads.ini'])
-            downloads.retrieve_downloads(download_info, downloads_cache, True, args.disable_ssl_verification)
+            downloads.retrieve_downloads(download_info, downloads_cache, None, True, args.disable_ssl_verification)
             try:
-                downloads.check_downloads(download_info, downloads_cache)
+                downloads.check_downloads(download_info, downloads_cache, None)
             except downloads.HashMismatchError as exc:
                 get_logger().error('File checksum does not match: %s', exc)
                 exit(1)
 
             # Unpack chromium tarball
             get_logger().info('Unpacking chromium tarball...')
-            downloads.unpack_downloads(download_info, downloads_cache, source_tree, None, extractors)
+            downloads.unpack_downloads(download_info, downloads_cache, None, source_tree, False, None, extractors)
         else:
             # Clone sources
             subprocess.run([sys.executable, str(Path('ungoogled-chromium', 'utils', 'clone.py')), '-o', 'build\\src', '-p', 'win32' if args.x86 else 'win64'], check=True)
@@ -198,9 +198,9 @@ def main():
         # Retrieve windows downloads
         get_logger().info('Downloading required files...')
         download_info_win = downloads.DownloadInfo([_ROOT_DIR / 'downloads.ini'])
-        downloads.retrieve_downloads(download_info_win, downloads_cache, True, args.disable_ssl_verification)
+        downloads.retrieve_downloads(download_info_win, downloads_cache, None, True, args.disable_ssl_verification)
         try:
-            downloads.check_downloads(download_info_win, downloads_cache)
+            downloads.check_downloads(download_info_win, downloads_cache, None)
         except downloads.HashMismatchError as exc:
             get_logger().error('File checksum does not match: %s', exc)
             exit(1)
@@ -217,7 +217,7 @@ def main():
 
         # Unpack downloads
         get_logger().info('Unpacking downloads...')
-        downloads.unpack_downloads(download_info_win, downloads_cache, source_tree, None, extractors)
+        downloads.unpack_downloads(download_info_win, downloads_cache, None, source_tree, False, None, extractors)
 
         # Apply patches
         # First, ungoogled-chromium-patches

--- a/package.py
+++ b/package.py
@@ -31,6 +31,20 @@ def _get_packaging_revision():
     revision_path = Path(__file__).resolve().parent / 'revision.txt'
     return revision_path.read_text(encoding=ENCODING).strip()
 
+_cached_target_cpu = None
+
+def _get_target_cpu(build_outputs):
+    global _cached_target_cpu
+    if not _cached_target_cpu:
+        with open(build_outputs / 'args.gn', 'r') as f:
+            args_gn_text = f.read()
+            for cpu in ('x64', 'x86'):
+                if f'target_cpu="{cpu}"' in args_gn_text:
+                    _cached_target_cpu = cpu
+                    break
+    assert _cached_target_cpu
+    return _cached_target_cpu
+
 def main():
     """Entrypoint"""
 
@@ -45,26 +59,35 @@ def main():
               'Default (from platform.architecture()): %(default)s'))
     args = parser.parse_args()
 
-    shutil.copyfile('build/src/out/Default/mini_installer.exe',
-        'build/ungoogled-chromium_{}-{}.{}_installer.exe'.format(
-            get_chromium_version(), _get_release_revision(), _get_packaging_revision()))
+    build_outputs = Path('build/src/out/Default')
 
-    # We need to remove these files, or they'll end up in the zip files that will be generated.
-    os.remove('build/src/out/Default/mini_installer.exe')
-    os.remove('build/src/out/Default/mini_installer_exe_version.rc')
-    os.remove('build/src/out/Default/setup.exe')
+    shutil.copyfile('build/src/out/Default/mini_installer.exe',
+        'build/ungoogled-chromium_{}-{}.{}_installer_{}.exe'.format(
+            get_chromium_version(), _get_release_revision(),
+            _get_packaging_revision(), _get_target_cpu(build_outputs)))
+
+    timestamp = None
     try:
-        os.remove('build/src/out/Default/chrome.packed.7z')
+        with open('build/src/build/util/LASTCHANGE.committime', 'r') as ct:
+            timestamp = int(ct.read())
     except FileNotFoundError:
         pass
 
-    build_outputs = Path('build/src/out/Default')
-    output = Path('build/ungoogled-chromium_{}-{}.{}_windows.zip'.format(
-        get_chromium_version(), _get_release_revision(), _get_packaging_revision()))
+    output = Path('build/ungoogled-chromium_{}-{}.{}_windows_{}.zip'.format(
+        get_chromium_version(), _get_release_revision(),
+        _get_packaging_revision(), _get_target_cpu(build_outputs)))
 
+    excluded_files = set([
+        Path('mini_installer.exe'),
+        Path('mini_installer_exe_version.rc'),
+        Path('setup.exe'),
+        Path('chrome.packed.7z'),
+    ])
     files_generator = filescfg.filescfg_generator(
-        Path('build/src/chrome/tools/build/win/FILES.cfg'), build_outputs, args.cpu_arch)
-    filescfg.create_archive(files_generator, tuple(), build_outputs, output)
+        Path('build/src/chrome/tools/build/win/FILES.cfg'),
+        build_outputs, args.cpu_arch, excluded_files)
+    filescfg.create_archive(
+        files_generator, tuple(), build_outputs, output, timestamp)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR depends on changes from [an associated PR](https://github.com/ungoogled-software/ungoogled-chromium/pull/3034) over in the main u-c repo. This is, likewise, a byproduct of my work on #293.

* Add the architecture identifier to the generated package files, so that x64 and x86 builds can be distinguished:

  |    | Installer | Zip file |
  |----|-----------|----------|
  | Old names | `ungoogled-chromium_123.0.4567.89-1.2_installer.exe` | `ungoogled-chromium_123.0.4567.89-1.2_windows.zip` |
  | New names | `ungoogled-chromium_123.0.4567.89-1.2_installer_x64.exe` | `ungoogled-chromium_123.0.4567.89-1.2_windows_x64.zip` |

  The build architecture is obtained by examining the `out/Default/args.gn` file (not sure if there's a better way).

* Look for the `build/util/LASTCHANGE.committime` file in the source tree, which contains the official timestamp for the Chromium release. If this file is present, then read the (Unix epoch format) timestamp therein, and pass it as a new parameter to `filescfg.create_archive()` so that the archive file can be created reproducibly.

  (If there is no timestamp, then member file timestamps go into the archive as-is, same as now.)

* Instead of deleting e.g. `mini_installer.exe` so that it doesn't get packed into the `.zip` file, use the new `excluded_files` parameter to `filescfg.filescfg_generator()`. This allows the packaging script to run idempotently---you can run it multiple times, and it won't bug out due to missing files after the first run.

  (I was running this script repeatedly in development, and having to rebuild/restore the missing files each time was quite tedious)