### PR TITLE
Misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 
 1. Setup the following:
     * 7-Zip
-    * Python 3.8 - 3.10 (for build and packaging scripts used below); Python 3.11 and above is not supported.
+    * Python 3.8 or above.
     * If you don't plan on using the Microsoft Store version of Python:
         * Check "Add python.exe to PATH" before install.
         * At the end of the Python installer, click the button to lift the `MAX_PATH` length restriction.  

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Or install using `winget install --id=eloston.ungoogled-chromium -e`.
 
 Google only supports [Windows 10 x64 or newer](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/windows_build_instructions.md#system-requirements). These instructions are tested on Windows 10 Pro x64.
 
-NOTE: The default configuration will build 64-bit binaries for maximum security (TODO: Link some explanation). This can be changed to 32-bit by setting `target_cpu` to `"x86"` in `flags.windows.gn`.
+NOTE: The default configuration will build 64-bit binaries for maximum security (TODO: Link some explanation). This can be changed to 32-bit by setting `target_cpu` to `"x86"` in `flags.windows.gn` or passing `--x86` as an argument to `build.py`.
 
 ### Setting up the build environment
 
@@ -37,17 +37,17 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 
 1. Setup the following:
     * 7-Zip
-    * Python 3.8 or above.
-    * If you don't plan on using the Microsoft Store version of Python:
-        * Check "Add python.exe to PATH" before install.
-        * At the end of the Python installer, click the button to lift the `MAX_PATH` length restriction.  
-        * Check that your `PATH` does not contain the `python3` wrapper shipped by Windows, as it will only prompt you to install Python from the Microsoft Store and exit. See [this question on stackoverflow.com](https://stackoverflow.com/questions/57485491/python-python3-executes-in-command-prompt-but-does-not-run-correctly)
-        * Ensure that your Python directory either has a copy of Python named "python3.exe" or a symlink linking to the Python executable.
+    * Python 3.8 or above
+		* Can be installed using WinGet or the Microsoft Store.
+		* If you don't plan on using the Microsoft Store version of Python:
+			* Check "Add python.exe to PATH" before install.
+			* At the end of the Python installer, click the button to lift the `MAX_PATH` length restriction.
+			* Disable the `python3.exe` and `python.exe` aliases in `Settings > Apps > Advanced app settings > App execution aliases`. They will typically be referred to as "App Installer". See [this question on stackoverflow.com](https://stackoverflow.com/questions/57485491/python-python3-executes-in-command-prompt-but-does-not-run-correctly) to understand why.
+			* Ensure that your Python directory either has a copy of Python named "python3.exe" or a symlink linking to the Python executable.
+		* The `httplib2` module. This can be installed using `pip install`.
     * Make sure to lift the `MAX_PATH` length restriction, either by clicking the button at the end of the Python installer or by [following these instructions](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#:~:text=Enable,Later).
     * Git (to fetch all required ungoogled-chromium scripts)
         * During setup, make sure "Git from the command line and also from 3rd-party software" is selected. This is usually the recommended option.
-    * The following additional python modules needs to be installed using `pip install`:
-        * httplib2
 
 ### Building
 
@@ -123,22 +123,40 @@ ln -s /usr/bin/vim /usr/bin/vi
 		* `cd ../..`
 	1. Sanity checking for consistency in series file
 		* `./devutils/check_patch_files.sh`
-1. Check for esbuild dependency changes in file `build/src/DEPS` and adapt `downloads.ini` accordingly
-1. Check for commit hash changes of `src` submodule in `third_party/microsoft_dxheaders` (e.g. using GitHub https://github.com/chromium/chromium/tree/127.0.6533.72/third_party/microsoft_dxheaders) and adapt `downloads.ini` accordingly
-1. Check for version changes of windows rust crate (`third_party/rust/windows_x86_64_msvc/`) and adapt `downloads.ini` and `patches/ungoogled-chromium/windows\windows-fix-building-with-rust.patch` accordingly
-1. Use git to add changes and commit
+1. Use Git to add changes and commit
+
+### Update dependencies
+
+**NOTE:** For all steps, update `downloads.ini` accordingly.
+
+1. Check the [LLVM GitHub](https://github.com/llvm/llvm-project/releases/) for the latest version of LLVM.
+1. Check the esbuild version in file `build/src/third_party/devtools-frontend/src/DEPS` and find the closest release in the [esbuild GitHub](https://github.com/evanw/esbuild/releases) to it.
+	* Example: `version:3@0.24.0.chromium.2` should be `0.24.0`
+1. Check the [ninja GitHub](https://github.com/ninja-build/ninja/releases/) for the latest version of ninja.
+	1. Download the `ninja-win.zip` file.
+	1. Get the SHA-512 checksum using `sha512sum` in **`MSYS2 MSYS`**.
+1. Check the [Git GitHub](https://github.com/git-for-windows/git/releases/) for the latest version of Git.
+	1. Get the SHA-256 checksum for `PortableGit-<version>-64-bit.7z.exe`.
+1. Check for commit hash changes of `src` submodule in `third_party/microsoft_dxheaders` (e.g. using GitHub `https://github.com/chromium/chromium/tree/<version>/third_party/microsoft_dxheaders`).
+	1. Replace `version` with the Chromium version in `ungoogled-chromium/chromium_version.txt`.
+1. Check the [NodeJS website](https://nodejs.org/en/download) for the latest **LTS** version of NodeJS.
+	1. Download the "Standalone Binary" version.
+	1. Get the SHA-256 checksum using `sha256sum` in **`MSYS2 MSYS`**.
+1. Check for version changes of windows rust crate (`third_party/rust/windows_x86_64_msvc/`).
+	1. Update `patches/ungoogled-chromium/windows/windows-fix-building-with-rust.patch` accordingly.
 
 ### Update rust
 1. Check `RUST_REVISION` constant in file `tools/rust/update_rust.py` in build root.
-	1. Current revision is `ab71ee7a9214c2793108a41efb065aa77aeb7326`
-1. Get date for nightly rust build from rust github page: `https://github.com/rust-lang/rust/commit/ab71ee7a9214c2793108a41efb065aa77aeb7326`
-	1. In this case, the corresponding nightly build date is `2024-04-12`
+	* Example: Revision could be `ab71ee7a9214c2793108a41efb065aa77aeb7326`
+1. Get date for nightly rust build from the Rust GitHub page: `https://github.com/rust-lang/rust/commit/<RUST_REVISION>`
+	1. Replace `RUST_REVISION` with the obtained value
 	1. Adapt `downloads.ini` accordingly
-1. Download nightly rust build from: https://static.rust-lang.org/dist/2024-04-12/rust-nightly-x86_64-pc-windows-msvc.tar.gz
+	* Example: The above revision corresponds to the nightly build date `2024-04-12` (`YYYY-mm-dd`)
+1. Download nightly rust build from: `https://static.rust-lang.org/dist/<build-date>/rust-nightly-x86_64-pc-windows-msvc.tar.gz`
+	1. Replace `build-date` with the obtained value
 	1. Extract archive
 	1. Execute `rustc\bin\rustc.exe -V` to get rust version string
-	1. Adapt `build.py` accordingly
-	1. Adapt `patches\ungoogled-chromium\windows\windows-fix-building-with-rust.patch` accordingly
+	1. Adapt `build.py` and `patches\ungoogled-chromium\windows\windows-fix-building-with-rust.patch` accordingly
 
 ## License
 

--- a/build.py
+++ b/build.py
@@ -10,11 +10,6 @@ ungoogled-chromium build script for Microsoft Windows
 
 import sys
 import time
-
-if sys.version_info.major != 3 or sys.version_info.minor < 8 or sys.version_info.minor > 10:
-    raise RuntimeError('Python 3.8 to 3.10 is required for this script. You have: {}.{}'.format(
-        sys.version_info.major, sys.version_info.minor))
-
 import argparse
 import os
 import re

--- a/build.py
+++ b/build.py
@@ -193,6 +193,14 @@ def main():
             parser.exit(1)
 
         # Unpack downloads
+        DIRECTX = source_tree / 'third_party' / 'microsoft_dxheaders' / 'src'
+        ESBUILD = source_tree / 'third_party' / 'devtools-frontend' / 'src' / 'third_party' / 'esbuild'
+        if DIRECTX.exists():
+            shutil.rmtree(DIRECTX)
+            DIRECTX.mkdir()
+        if ESBUILD.exists():
+            shutil.rmtree(ESBUILD)
+            ESBUILD.mkdir()
         get_logger().info('Unpacking downloads...')
         downloads.unpack_downloads(download_info_win, downloads_cache, None, source_tree, extractors)
 


### PR DESCRIPTION
This PR does the following:

* Drop maximum Python version requirements (I'm building with Python 3.13 and did not encounter any problems).
* Purge `esbuild` and `dxheaders` directories, as they are ignored each time the browser source code is resynced.
* Add a section dedicated to updating dependencies for the browser in `README.md`.
* Mention passing `--x86` as an argument for 32-bit builds.

More information can be found in the commit messages.