### PR TITLE
Start building ARM64 binaries

### DIFF
--- a/.github/actions/stage/action.yml
+++ b/.github/actions/stage/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Build x86 binary
     required: false
     default: false
+  arm:
+    description: Build arm binary
+    required: false
+    default: false
 outputs:
   finished:
     description: If a previous stage already finished the build, the stage will set all output variables to the input ones and exit

--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -10,6 +10,7 @@ async function run() {
     const finished = core.getBooleanInput('finished', {required: true});
     const from_artifact = core.getBooleanInput('from_artifact', {required: true});
     const x86 = core.getBooleanInput('x86', {required: false})
+    const arm = core.getBooleanInput('arm', {required: false})
     console.log(`finished: ${finished}, artifact: ${from_artifact}`);
     if (finished) {
         core.setOutput('finished', true);
@@ -17,7 +18,7 @@ async function run() {
     }
 
     const artifact = new DefaultArtifactClient();
-    const artifactName = x86 ? 'build-artifact-x86' : 'build-artifact';
+    const artifactName = x86 ? 'build-artifact-x86' : (arm ? 'build-artifact-arm' : 'build-artifact');
 
     if (from_artifact) {
         const artifactInfo = await artifact.getArtifact(artifactName);
@@ -30,6 +31,8 @@ async function run() {
     const args = ['build.py', '--ci']
     if (x86)
         args.push('--x86')
+    if (arm)
+        args.push('--arm')
     await exec.exec('python', ['-m', 'pip', 'install', 'httplib2'], {
         cwd: 'C:\\ungoogled-chromium-windows',
         ignoreReturnCode: true
@@ -43,7 +46,7 @@ async function run() {
         const globber = await glob.create('C:\\ungoogled-chromium-windows\\build\\ungoogled-chromium*',
             {matchDirectories: false});
         let packageList = await globber.glob();
-        const finalArtifactName = x86 ? 'chromium-x86' : 'chromium';
+        const finalArtifactName = x86 ? 'chromium-x86' : (arm ? 'chromium-arm' : 'chromium');
         for (let i = 0; i < 5; ++i) {
             try {
                 await artifact.deleteArtifact(finalArtifactName);

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -692,8 +692,360 @@ jobs:
     outputs:
       finished: ${{ steps.stage.outputs.finished }}
 
+  build-arm-1:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: false
+          from_artifact: false
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-2:
+    needs: build-arm-1
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-3:
+    needs: build-arm-2
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-4:
+    needs: build-arm-3
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-5:
+    needs: build-arm-4
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-6:
+    needs: build-arm-5
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-7:
+    needs: build-arm-6
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-8:
+    needs: build-arm-7
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-9:
+    needs: build-arm-8
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-10:
+    needs: build-arm-9
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-11:
+    needs: build-arm-10
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-12:
+    needs: build-arm-11
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-13:
+    needs: build-arm-12
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-14:
+    needs: build-arm-13
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-15:
+    needs: build-arm-14
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+  build-arm-16:
+    needs: build-arm-15
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Init
+        run: Copy-Item -Path . -Destination "C:\ungoogled-chromium-windows" -Recurse
+      - name: Setup Stage
+        run: npm install
+        working-directory: ./.github/actions/stage
+      - name: Run Stage
+        id: stage
+        uses: ./.github/actions/stage
+        with:
+          finished: ${{ join(needs.*.outputs.finished) }}
+          from_artifact: true
+          arm: true
+    outputs:
+      finished: ${{ steps.stage.outputs.finished }}
+
   publish-release:
-    needs: [build-16, build-x86-16]
+    needs: [build-16, build-x86-16, build-arm-16]
     runs-on: ubuntu-latest
     steps:
       - name: Download package
@@ -704,6 +1056,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: chromium-x86
+      - name: Download arm package
+        uses: actions/download-artifact@v4
+        with:
+          name: chromium-arm
       - name: Publish release
         id: publish
         uses: softprops/action-gh-release@v1

--- a/build.py
+++ b/build.py
@@ -174,7 +174,7 @@ def main():
             downloads.unpack_downloads(download_info, downloads_cache, None, source_tree, extractors)
         else:
             # Clone sources
-            subprocess.run([sys.executable, str(Path('ungoogled-chromium', 'utils', 'clone.py')), '-o', 'build\\src', '-p', 'win32' if args.x86 else 'win64'], check=True)
+            subprocess.run([sys.executable, str(Path('ungoogled-chromium', 'utils', 'clone.py')), '-o', 'build\\src', '-p', 'win32' if args.x86 else 'win-arm64' if args.arm else 'win64'], check=True)
 
         # Retrieve windows downloads
         get_logger().info('Downloading required files...')

--- a/build.py
+++ b/build.py
@@ -132,6 +132,10 @@ def main():
         action='store_true'
     )
     parser.add_argument(
+        '--arm',
+        action='store_true'
+    )
+    parser.add_argument(
         '--tarball',
         action='store_true'
     )
@@ -271,6 +275,8 @@ def main():
         windows_flags = (_ROOT_DIR / 'flags.windows.gn').read_text(encoding=ENCODING)
         if args.x86:
             windows_flags = windows_flags.replace('x64', 'x86')
+        elif args.arm:
+            windows_flags = windows_flags.replace('x64', 'arm64')
         gn_flags += windows_flags
         (source_tree / 'out/Default/args.gn').write_text(gn_flags, encoding=ENCODING)
 

--- a/build.py
+++ b/build.py
@@ -236,13 +236,14 @@ def main():
     RUST_DIR_DST = source_tree / 'third_party' / 'rust-toolchain'
     RUST_DIR_SRC64 = source_tree / 'third_party' / 'rust-toolchain-x64'
     RUST_DIR_SRC86 = source_tree / 'third_party' / 'rust-toolchain-x86'
+    RUST_DIR_SRCARM = source_tree / 'third_party' / 'rust-toolchain-arm'
     RUST_FLAG_FILE = RUST_DIR_DST / 'INSTALLED_VERSION'
     if not args.ci or not RUST_FLAG_FILE.exists():
         # Directories to copy from source to target folder
         DIRS_TO_COPY = ['bin', 'lib']
 
         # Loop over all source folders
-        for rust_dir_src in [RUST_DIR_SRC64, RUST_DIR_SRC86]:
+        for rust_dir_src in [RUST_DIR_SRC64, RUST_DIR_SRC86, RUST_DIR_SRCARM]:
             # Loop over all dirs to copy
             for dir_to_copy in DIRS_TO_COPY:
                 # Copy bin folder for host architecture

--- a/downloads.ini
+++ b/downloads.ini
@@ -124,6 +124,12 @@ url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-i686-pc-windows
 download_filename = rust-nightly-%(version)s-i686-pc-windows-msvc.tar.gz
 output_path = third_party/rust-toolchain-x86
 strip_leading_dirs=rust-nightly-i686-pc-windows-msvc
+[rust-arm]
+version = 2025-01-07
+url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-pc-windows-msvc.tar.gz
+download_filename = rust-nightly-%(version)s-aarch64-pc-windows-msvc.tar.gz
+output_path = third_party/rust-toolchain-arm
+strip_leading_dirs=rust-nightly-aarch64-pc-windows-msvc
 [rust-windows-create]
 version = 0.52.0
 url = https://github.com/microsoft/windows-rs/archive/refs/tags/%(version)s.zip

--- a/package.py
+++ b/package.py
@@ -38,7 +38,7 @@ def _get_target_cpu(build_outputs):
     if not _cached_target_cpu:
         with open(build_outputs / 'args.gn', 'r') as f:
             args_gn_text = f.read()
-            for cpu in ('x64', 'x86'):
+            for cpu in ('x64', 'x86', 'arm64'):
                 if f'target_cpu="{cpu}"' in args_gn_text:
                     _cached_target_cpu = cpu
                     break

--- a/patches/ungoogled-chromium/windows/windows-fix-building-with-rust.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-with-rust.patch
@@ -29,6 +29,41 @@
  
    # If you're using a Rust toolchain as specified by rust_sysroot_absolute,
    # you can specify whether it supports nacl here.
+--- a/third_party/rust/windows_aarch64_msvc/v0_52/BUILD.gn
++++ b/third_party/rust/windows_aarch64_msvc/v0_52/BUILD.gn
+@@ -12,13 +12,13 @@ cargo_crate("lib") {
+   crate_name = "windows_i686_msvc"
+   epoch = "0.52"
+   crate_type = "rlib"
+-  crate_root = "//third_party/rust/chromium_crates_io/vendor/windows_aarch64_msvc-0.52.6/src/lib.rs"
+-  sources = [ "//third_party/rust/chromium_crates_io/vendor/windows_aarch64_msvc-0.52.6/src/lib.rs" ]
++  crate_root = "//third_party/rust/chromium_crates_io/vendor/windows-rs-0.52.0/crates/targets/aarch64_msvc/src/lib.rs"
++  sources = [ "//third_party/rust/chromium_crates_io/vendor/windows-rs-0.52.0/crates/targets/aarch64_msvc/src/lib.rs" ]
+   inputs = []
+ 
+   build_native_rust_unit_tests = false
+   edition = "2021"
+-  cargo_pkg_version = "0.52.6"
++  cargo_pkg_version = "0.52.0"
+   cargo_pkg_authors = "Microsoft"
+   cargo_pkg_name = "windows_i686_msvc"
+   cargo_pkg_description = "Import lib for Windows"
+@@ -28,12 +28,12 @@ cargo_crate("lib") {
+   executable_configs += [ "//build/config/compiler:no_chromium_code" ]
+   proc_macro_configs -= [ "//build/config/compiler:chromium_code" ]
+   proc_macro_configs += [ "//build/config/compiler:no_chromium_code" ]
+-  build_root = "//third_party/rust/chromium_crates_io/vendor/windows_aarch64_msvc-0.52.6/build.rs"
+-  build_sources = [ "//third_party/rust/chromium_crates_io/vendor/windows_aarch64_msvc-0.52.6/build.rs" ]
++  build_root = "//third_party/rust/chromium_crates_io/vendor/windows-rs-0.52.0/crates/targets/aarch64_msvc/build.rs"
++  build_sources = [ "//third_party/rust/chromium_crates_io/vendor/windows-rs-0.52.0/crates/targets/aarch64_msvc/build.rs" ]
+   rustflags = [
+     "--cap-lints=allow",  # Suppress all warnings in crates.io crates
+   ]
+-  native_libs = [ "//third_party/rust/chromium_crates_io/vendor/windows_aarch64_msvc-0.52.6/src/../lib/windows.0.52.0.lib" ]
++  native_libs = [ "//third_party/rust/chromium_crates_io/vendor/windows-rs-0.52.0/crates/targets/aarch64_msvc/lib/windows.0.52.0.lib" ]
+ 
+   # Only for usage from third-party crates. Add the crate to
+   # //third_party/rust/chromium_crates_io/Cargo.toml to use
 --- a/third_party/rust/windows_i686_msvc/v0_52/BUILD.gn
 +++ b/third_party/rust/windows_i686_msvc/v0_52/BUILD.gn
 @@ -12,13 +12,13 @@ cargo_crate("lib") {


### PR DESCRIPTION
Closes #387.

Now that my patch for downloading ARM64 PGO has been [merged upstream](https://github.com/ungoogled-software/ungoogled-chromium/pull/3255), we can start building ARM64 binaries for Windows.