### PR TITLE
Enable PGO in build configuration

### DIFF
--- a/flags.windows.gn
+++ b/flags.windows.gn
@@ -1,4 +1,4 @@
-chrome_pgo_phase=0
+chrome_pgo_phase=2
 enable_swiftshader=false
 ffmpeg_branding="Chrome"
 is_clang=true


### PR DESCRIPTION
The project has already downloaded the PGO profile during the build, but has not yet used the PGO profile in compilation. This PR modifies chrome_pgo_phase to 2 to enable PGO.
In comparison, the size of the x64 installer for 135.0.7049.41 has been reduced from 102MB to 98.8MB, with a significant improvement in performance as well.