### PR TITLE
Implement dynamic timeout for GitHub Actions builds

### DIFF
--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -17,6 +17,7 @@ async function run() {
         return;
     }
 
+    const startTime = Date.now();
     const artifact = new DefaultArtifactClient();
     const artifactName = x86 ? 'build-artifact-x86' : (arm ? 'build-artifact-arm' : 'build-artifact');
 
@@ -33,13 +34,20 @@ async function run() {
         args.push('--x86')
     if (arm)
         args.push('--arm')
+
+    const env = {
+        ...process.env,
+        GH_ACTIONS_START_TIME: startTime.toString()
+    };
+
     await exec.exec('python', ['-m', 'pip', 'install', 'httplib2'], {
         cwd: 'C:\\ungoogled-chromium-windows',
         ignoreReturnCode: true
     });
     const retCode = await exec.exec('python', args, {
         cwd: 'C:\\ungoogled-chromium-windows',
-        ignoreReturnCode: true
+        ignoreReturnCode: true,
+        env: env
     });
     if (retCode === 0) {
         core.setOutput('finished', true);


### PR DESCRIPTION
add dynamic timeout for GitHub Actions builds

- add build start time tracking in GitHub Actions workflow
- implement dynamic timeout calculation based on elapsed time
- pass start time from actions to build script via environment variable
- ensure builds reserve a buffer time before GitHub's 6-hour limit

actual operation:
https://github.com/vpday/ungoogled-chromium-windows/actions/runs/14676378595