### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 
 1. Setup the following:
     * 7-Zip
-    * Python 3.8 or above
+    * Python 3.8 or above (see note below for Python 3.12 or later)
 		* Can be installed using WinGet or the Microsoft Store.
 		* If you don't plan on using the Microsoft Store version of Python:
 			* Check "Add python.exe to PATH" before install.
@@ -45,6 +45,7 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 			* Disable the `python3.exe` and `python.exe` aliases in `Settings > Apps > Advanced app settings > App execution aliases`. They will typically be referred to as "App Installer". See [this question on stackoverflow.com](https://stackoverflow.com/questions/57485491/python-python3-executes-in-command-prompt-but-does-not-run-correctly) to understand why.
 			* Ensure that your Python directory either has a copy of Python named "python3.exe" or a symlink linking to the Python executable.
 		* The `httplib2` module. This can be installed using `pip install`.
+	    * For Python 3.12 and later: the build.py script relies on distutils, which is removed from the standard library in 3.12. It is now provided by the setuptools library. Install it via `pip install setuptools`.
     * Make sure to lift the `MAX_PATH` length restriction, either by clicking the button at the end of the Python installer or by [following these instructions](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#:~:text=Enable,Later).
     * Git (to fetch all required ungoogled-chromium scripts)
         * During setup, make sure "Git from the command line and also from 3rd-party software" is selected. This is usually the recommended option.


### PR DESCRIPTION
Update README.md to add a note regarding the need to pip install setuptools for python 3.12 and later. The removal of distutils from the standard library in 3.12 and later otherwise breaks the build.py script.