### PR TITLE
Fix release tag handling in publish workflows

### DIFF
--- a/.github/scripts/gen.py
+++ b/.github/scripts/gen.py
@@ -4,7 +4,7 @@ import os
 
 import requests
 
-tag = os.environ['GITHUB_REF_NAME']
+tag = os.environ.get('RELEASE_TAG') or os.environ['GITHUB_REF_NAME']
 config = [
     ('32bit', 'x86'),
     ('64bit', 'x64'),

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -203,6 +203,7 @@ jobs:
           token: ${{ secrets.PAT }}
           installers-regex: .(exe|zip)$
           version: ${{ steps.version.outputs.version }}
+          release-tag: ${{ needs.resolve-release-context.outputs.target_tag }}
           fork-user: Nifury
 
   update-binaries:
@@ -239,6 +240,8 @@ jobs:
         run: pip install requests
       - name: Run gen.py
         working-directory: ungoogled-chromium-binaries
+        env:
+          RELEASE_TAG: ${{ needs.resolve-release-context.outputs.target_tag }}
         run: python ../ungoogled-chromium-windows/.github/scripts/gen.py
       - name: Commit and push
         working-directory: ungoogled-chromium-binaries


### PR DESCRIPTION
`publish-release` can run from `workflow_run`, where `GITHUB_REF_NAME` is `master` instead of the actual release tag. That breaks both `winget-releaser` and `.github/scripts/gen.py`, which then try to fetch release assets from the wrong tag and fail with 404s.

This change passes the resolved `target_tag` into both paths:
- use `needs.resolve-release-context.outputs.target_tag` as `release-tag` for `winget-releaser`
- pass `RELEASE_TAG` to `gen.py`
- make `gen.py` prefer `RELEASE_TAG` over `GITHUB_REF_NAME`