### PR TITLE
Update to 147.0.7727.101

### DIFF
--- a/build.py
+++ b/build.py
@@ -163,7 +163,7 @@ def main():
         }
 
         # Prepare source folder
-        if args.tarball:
+        if args.tarball or args.ci:
             # Download chromium tarball
             get_logger().info('Downloading chromium tarball...')
             download_info = downloads.DownloadInfo([_ROOT_DIR / 'ungoogled-chromium' / 'downloads.ini'])

--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -2968,6 +2968,7 @@ components/contextual_tasks/public/contextual_task_context_unittest.cc
 components/contextual_tasks/public/contextual_task_unittest.cc
 components/contextual_tasks/public/features.cc
 components/contextual_tasks/public/features_unittest.cc
+components/contextual_tasks/public/query_contextualizer_unittest.cc
 components/continuous_search/browser/search_result_extractor_client_unittest.cc
 components/country_codes/country_codes.cc
 components/crash/core/app/crash_export_thunks.h
@@ -3307,6 +3308,7 @@ components/optimization_guide/optimization_guide_internals/resources/optimizatio
 components/optimization_guide/tools/gen_on_device_proto_descriptors.py
 components/origin_trials/browser/leveldb_persistence_provider_unittest.cc
 components/os_crypt/sync/libsecret_util_linux.cc
+components/page_content_annotations/core/category_classifier_model_handler_unittest.cc
 components/page_content_annotations/core/on_device_category_classifier_unittest.cc
 components/page_content_annotations/core/page_content_annotations_service_unittest.cc
 components/page_image_service/image_service_impl_unittest.cc

--- a/flags.windows.gn
+++ b/flags.windows.gn
@@ -1,4 +1,4 @@
-chrome_pgo_phase=2
+chrome_pgo_phase=0
 enable_swiftshader=false
 ffmpeg_branding="Chrome"
 is_clang=true

--- a/patches/series
+++ b/patches/series
@@ -21,3 +21,4 @@ ungoogled-chromium/windows/windows-fix-building-with-rust.patch
 ungoogled-chromium/windows/windows-fix-remove-unused-preferences-fields.patch
 ungoogled-chromium/windows/windows-fix-missing-includes.patch
 ungoogled-chromium/windows/windows-fix-unsupported-llvm-flags.patch
+ungoogled-chromium/windows/windows-fix-glic.patch

--- a/patches/ungoogled-chromium/windows/windows-fix-glic.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-glic.patch
@@ -1,0 +1,13 @@
+--- a/chrome/browser/actor/actor_keyed_service_factory.cc
++++ b/chrome/browser/actor/actor_keyed_service_factory.cc
+@@ -15,7 +15,9 @@ namespace actor {
+ // static
+ ActorKeyedService* ActorKeyedServiceFactory::GetActorKeyedService(
+     content::BrowserContext* browser_context) {
+-   return nullptr;
++  return static_cast<ActorKeyedService*>(
++      GetInstance()->GetServiceForBrowserContext(browser_context,
++                                                 /*create=*/true));
+ }
+ 
+ // static


### PR DESCRIPTION
Notable changes:

* CI temporarily builds from tarball due to recent updates in the `DEPS` file. (https://github.com/ungoogled-software/ungoogled-chromium/pull/3738#issuecomment-4256065678)
* Temporarily disable PGO
* Add `windows-fix-glic.patch` to revert the `actor_keyed_service_factory.cc` patch in https://github.com/ungoogled-software/ungoogled-chromium/blob/9805b3260c287f8c19afd3978ed057fa3ebe450c/patches/core/ungoogled-chromium/fix-building-with-prunned-binaries.patch#L21-L24. Thanks @sharifpour and @FriedGenera for pinpointing the issue. There are more places where `ActorKeyedServiceFactory::GetActorKeyedService` is used without checking the return value, so reverting the original change is simplier. 

Fixes https://github.com/ungoogled-software/ungoogled-chromium-windows/issues/562