### PR TITLE
Add `v8_enable_drumbrake=false` for x86 build

### DIFF
--- a/build.py
+++ b/build.py
@@ -280,6 +280,7 @@ def main():
         windows_flags = (_ROOT_DIR / 'flags.windows.gn').read_text(encoding=ENCODING)
         if args.x86:
             windows_flags = windows_flags.replace('x64', 'x86')
+            windows_flags += '\nv8_enable_drumbrake=false\n'
         elif args.arm:
             windows_flags = windows_flags.replace('x64', 'arm64')
         if args.tarball:


### PR DESCRIPTION
Fixes https://github.com/ungoogled-software/ungoogled-chromium/issues/3792

I think it should be fine to reset the tag `148.0.7778.178-1.1` to this commit since it has not been released yet.