### PR TITLE
Pass `--cpu-arch` to package.py in CI mode

### DIFF
--- a/build.py
+++ b/build.py
@@ -322,7 +322,7 @@ def main():
         _run_build_process_timeout(*ninja_commandline, timeout=3.5*60*60)
         # package
         os.chdir(_ROOT_DIR)
-        subprocess.run([sys.executable, 'package.py'])
+        subprocess.run([sys.executable, 'package.py', '--cpu-arch', '32bit' if args.x86 else 'arm' if args.arm else '64bit'])
     else:
         _run_build_process(*ninja_commandline)
 

--- a/package.py
+++ b/package.py
@@ -53,7 +53,7 @@ def main():
         '--cpu-arch',
         metavar='ARCH',
         default=platform.architecture()[0],
-        choices=('64bit', '32bit'),
+        choices=('64bit', '32bit', 'arm'),
         help=('Filter build outputs by a target CPU. '
               'This is the same as the "arch" key in FILES.cfg. '
               'Default (from platform.architecture()): %(default)s'))


### PR DESCRIPTION
Pass `--cpu-arch` to package.py in CI mode so that arch specific files in FILES.cfg are included in the zip file. 