### PR TITLE
Migrate stage action from Node.js 16 to Node.js 24

### DIFF
--- a/.github/actions/stage/action.yml
+++ b/.github/actions/stage/action.yml
@@ -19,5 +19,5 @@ outputs:
   finished:
     description: If a previous stage already finished the build, the stage will set all output variables to the input ones and exit
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'index.js'

--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -1,8 +1,8 @@
-const core = require('@actions/core');
-const io = require('@actions/io');
-const exec = require('@actions/exec');
-const {DefaultArtifactClient} = require('@actions/artifact');
-const glob = require('@actions/glob');
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as exec from '@actions/exec';
+import { DefaultArtifactClient } from '@actions/artifact';
+import * as glob from '@actions/glob';
 
 async function run() {
     process.on('SIGINT', function() {

--- a/.github/actions/stage/package.json
+++ b/.github/actions/stage/package.json
@@ -1,9 +1,10 @@
 {
+  "type": "module",
   "dependencies": {
-    "@actions/artifact": "^2.2.1",
-    "@actions/core": "^1.8.2",
-    "@actions/exec": "^1.1.1",
-    "@actions/glob": "^0.3.0",
-    "@actions/io": "^1.1.2"
+    "@actions/artifact": "^6.2.1",
+    "@actions/core": "^3.0.0",
+    "@actions/exec": "^3.0.0",
+    "@actions/glob": "^0.7.0",
+    "@actions/io": "^3.0.2"
   }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/.github/actions/stage"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,7 +31,7 @@ jobs:
       arm_run_id: ${{ steps.runs.outputs.arm_run_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
       - name: Locate latest successful builds
         id: runs
         if: ${{ steps.context.outputs.ready == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           TARGET_SHA: ${{ steps.context.outputs.target_sha }}
         with:
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download x64 package
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: chromium
           path: artifacts/x64
@@ -161,7 +161,7 @@ jobs:
           run-id: ${{ needs.resolve-release-context.outputs.x64_run_id }}
 
       - name: Download x86 package
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: chromium-x86
           path: artifacts/x86
@@ -170,7 +170,7 @@ jobs:
           run-id: ${{ needs.resolve-release-context.outputs.x86_run_id }}
 
       - name: Download arm package
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: chromium-arm
           path: artifacts/arm
@@ -179,7 +179,7 @@ jobs:
           run-id: ${{ needs.resolve-release-context.outputs.arm_run_id }}
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.resolve-release-context.outputs.target_tag }}
           fail_on_unmatched_files: true
@@ -214,12 +214,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ungoogled-chromium-windows
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-release-context.outputs.target_tag }}
           path: ungoogled-chromium-windows
       - name: Checkout ungoogled-chromium-binaries
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Nifury/ungoogled-chromium-binaries
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
GitHub Actions is deprecating the Node.js 20 runtime and will force Node.js 24 by default starting June 16, 2026[^1]. The stage action was still pinned to `node16`, which triggers deprecation warnings and will break once the old runtimes are removed.

**Changes**

- `action.yml`: `runs.using` bumped from `node16` to `node24`
- `index.js`: migrated from CommonJS (`require`) to ESM (`import`)
- `package.json`: added `"type": "module"` and upgraded `@actions/*` packages (core, exec, io to v3, artifact to v6, glob to v0.7)

**Validated**

Tested with a `workflow_dispatch` build on the `fix` branch:
https://github.com/vpday/ungoogled-chromium-windows/actions/runs/27001444572

[^1]: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/