### PR TITLE
Distinguish build timeouts from fatal errors

### DIFF
--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -68,8 +68,7 @@ async function run() {
     } else if (retCode === BUILD_TIMEOUT_EXIT_CODE) {
         await new Promise(r => setTimeout(r, 5000));
         await exec.exec('7z', ['a', '-tzip', 'C:\\ungoogled-chromium-windows\\artifacts.zip',
-            'C:\\ungoogled-chromium-windows\\build\\src', '-mx=3', '-mtc=on']);
-        let uploaded = false;
+            'C:\\ungoogled-chromium-windows\\build\\src', '-mx=3', '-mtc=on'], {ignoreReturnCode: true});
         for (let i = 0; i < 5; ++i) {
             try {
                 await artifact.deleteArtifact(artifactName);
@@ -79,16 +78,12 @@ async function run() {
             try {
                 await artifact.uploadArtifact(artifactName, ['C:\\ungoogled-chromium-windows\\artifacts.zip'],
                     'C:\\ungoogled-chromium-windows', {retentionDays: 4, compressionLevel: 0});
-                uploaded = true;
                 break;
             } catch (e) {
                 console.error(`Upload artifact failed: ${e}`);
                 // Wait 10 seconds between the attempts
                 await new Promise(r => setTimeout(r, 10000));
             }
-        }
-        if (!uploaded) {
-            throw new Error(`Failed to upload ${artifactName} after 5 attempts`);
         }
         core.setOutput('finished', false);
     } else {

--- a/.github/actions/stage/index.js
+++ b/.github/actions/stage/index.js
@@ -4,6 +4,8 @@ import * as exec from '@actions/exec';
 import { DefaultArtifactClient } from '@actions/artifact';
 import * as glob from '@actions/glob';
 
+const BUILD_TIMEOUT_EXIT_CODE = 124;
+
 async function run() {
     process.on('SIGINT', function() {
     })
@@ -63,10 +65,11 @@ async function run() {
                 await new Promise(r => setTimeout(r, 10000));
             }
         }
-    } else {
+    } else if (retCode === BUILD_TIMEOUT_EXIT_CODE) {
         await new Promise(r => setTimeout(r, 5000));
         await exec.exec('7z', ['a', '-tzip', 'C:\\ungoogled-chromium-windows\\artifacts.zip',
-            'C:\\ungoogled-chromium-windows\\build\\src', '-mx=3', '-mtc=on'], {ignoreReturnCode: true});
+            'C:\\ungoogled-chromium-windows\\build\\src', '-mx=3', '-mtc=on']);
+        let uploaded = false;
         for (let i = 0; i < 5; ++i) {
             try {
                 await artifact.deleteArtifact(artifactName);
@@ -76,6 +79,7 @@ async function run() {
             try {
                 await artifact.uploadArtifact(artifactName, ['C:\\ungoogled-chromium-windows\\artifacts.zip'],
                     'C:\\ungoogled-chromium-windows', {retentionDays: 4, compressionLevel: 0});
+                uploaded = true;
                 break;
             } catch (e) {
                 console.error(`Upload artifact failed: ${e}`);
@@ -83,7 +87,12 @@ async function run() {
                 await new Promise(r => setTimeout(r, 10000));
             }
         }
+        if (!uploaded) {
+            throw new Error(`Failed to upload ${artifactName} after 5 attempts`);
+        }
         core.setOutput('finished', false);
+    } else {
+        throw new Error(`Build failed with exit code ${retCode}`);
     }
 }
 

--- a/build.py
+++ b/build.py
@@ -28,6 +28,11 @@ sys.path.pop(0)
 
 _ROOT_DIR = Path(__file__).resolve().parent
 _PATCH_BIN_RELPATH = Path('third_party/git/usr/bin/patch.exe')
+_BUILD_TIMEOUT_EXIT_CODE = 124
+
+
+class _BuildTimeout(Exception):
+    """Raised when the CI build time limit is reached."""
 
 
 def _get_vcvars_path(name='64'):
@@ -91,7 +96,7 @@ def _run_build_process_timeout(*args, timeout):
                 proc.wait(10)
             except:
                 proc.kill()
-            raise KeyboardInterrupt
+            raise _BuildTimeout
 
 
 def _make_tmp_paths():
@@ -327,4 +332,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except _BuildTimeout:
+        sys.exit(_BUILD_TIMEOUT_EXIT_CODE)


### PR DESCRIPTION
## Summary

- Treat only controlled build timeouts as resumable stage exits.
- Fail the stage action for other build errors instead of uploading a resume artifact.
- Fail when creating or uploading a resume artifact is unsuccessful.

## Validation

The [GitHub Actions run](https://github.com/vpday/ungoogled-chromium-windows/actions/runs/31873076021) stopped `build-1` on a Ninja failure with exit code 1, and dependent build jobs were skipped.